### PR TITLE
add wrapper convenience functions, and session.close

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1.3.0"
 futures = "0.3.26"
 lazy_static = "1.4.0"
 log = "0.4"
-ngrok = { version = "=0.10.2" }
+ngrok = { version = "0.11.0" }
 pyo3 = { version = "0.18.1", features = ["abi3", "abi3-py37", "extension-module", "multiple-pymethods"]}
 pyo3-asyncio = { version = "0.18.0", features = ["attributes", "tokio-runtime"] }
 pyo3-log = { version = "0.8.1" }

--- a/README.md
+++ b/README.md
@@ -17,11 +17,9 @@
 [ci-badge]: https://github.com/ngrok/ngrok-py/actions/workflows/ci.yml/badge.svg
 [ci-url]: https://github.com/ngrok/ngrok-py/actions/workflows/ci.yml
 
-[Website](https://ngrok.com)
-
 **Note: This is alpha-quality software. Interfaces are subject to change without warning.**
 
-ngrok is a globally distributed reverse proxy commonly used for quickly getting a public URL to a
+[ngrok](https://ngrok.com) is a globally distributed reverse proxy commonly used for quickly getting a public URL to a
 service running inside a private network, such as on your local laptop. The ngrok agent is usually
 deployed inside a private network and is used to communicate with the ngrok cloud service.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,18 @@
 Release Instructions
 --------------------
+
+Pre-Commit
+----------
+1. fix-n-fmt
+1. make test
+
+Release
+-------
 1. `git checkout main; git pull origin main`
 1. `git checkout -b <username>/<version>`
 1. Bump patch number in `version` in `Cargo.toml`
+1. make docs
+1. `git add .`
 1. `git commit -m '<version>'`
 1. `git push origin <username>/<version>`
 1. Create a pull request off this branch

--- a/doc_source/conf.py
+++ b/doc_source/conf.py
@@ -3,11 +3,15 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import http
+from http.server import HTTPServer
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'ngrok'
-copyright = '2023, ngrok'
+# note the space prefix is required, or sphinx will convert 2023 to 1980
+copyright = ' 2023, ngrok'
 author = 'ngrok'
 
 # -- General configuration ---------------------------------------------------

--- a/doc_source/module.rst
+++ b/doc_source/module.rst
@@ -2,6 +2,6 @@ Ngrok Module
 =====================================
 
 .. automodule:: ngrok
-   :members: log_level
+   :members: default, fd, getsockname, listen, log_level, pipe_name, werkzeug_develop
    :noindex:
 

--- a/examples/aiohttp-test.py
+++ b/examples/aiohttp-test.py
@@ -1,28 +1,12 @@
 #!/usr/bin/env python
 
-import asyncio
 from aiohttp import web
-from ngrok import NgrokSessionBuilder
-import os
+import logging, ngrok
 
-UNIX_SOCKET = "/tmp/http.socket"
-if os.path.exists(UNIX_SOCKET):
-    os.remove(UNIX_SOCKET)
-
-# start tunnel
-async def create_tunnel():
-  session = await NgrokSessionBuilder().authtoken_from_env().connect()
-  tunnel = await session.http_endpoint().listen()
-  print("established tunnel at: {}".format(tunnel.url()))
-  await tunnel.forward_pipe(UNIX_SOCKET)
-
-loop = asyncio.new_event_loop()
-loop.create_task(create_tunnel())
-
-# start web server
 async def hello(request):
   return web.Response(text="Hello, world")
 
+logging.basicConfig(level=logging.INFO)
 app = web.Application()
 app.add_routes([web.get('/', hello)])
-web.run_app(app, path=UNIX_SOCKET, loop=loop)
+web.run_app(app, sock=ngrok.listen())

--- a/examples/flask-test.py
+++ b/examples/flask-test.py
@@ -1,23 +1,13 @@
 #!/usr/bin/env python
 
-import asyncio
-import flask
-from ngrok import NgrokSessionBuilder
-import os
+import flask, ngrok
 
-# start tunnel
-async def create_tunnel():
-  session = await NgrokSessionBuilder().authtoken_from_env().connect()
-  tunnel = await session.http_endpoint().listen()
-  print("tunnel at: {}".format(tunnel.url()))
-  tunnel.forward_tcp('localhost:9000')
-
-loop = asyncio.new_event_loop()
-loop.run_until_complete(create_tunnel())
+tunnel = ngrok.werkzeug_develop()
+print("tunnel established at: {}".format(tunnel.url()))
 
 if __name__ == "__main__":
   app = flask.Flask(__name__)
   @app.route('/')
   def hello():
     return 'Hello, World!'
-  app.run(host='localhost', port=9000, debug=True)
+  app.run()

--- a/examples/ngrok-http-minimal.py
+++ b/examples/ngrok-http-minimal.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
-import asyncio
 from http.server import HTTPServer, BaseHTTPRequestHandler
-from ngrok import NgrokSessionBuilder
+import logging, ngrok
 
 class HelloHandler(BaseHTTPRequestHandler):
   def do_GET(self):
@@ -13,11 +12,7 @@ class HelloHandler(BaseHTTPRequestHandler):
     self.end_headers()
     self.wfile.write(body)
 
-async def create_tunnel():
-  session = await NgrokSessionBuilder().authtoken_from_env().connect()
-  tunnel = await session.http_endpoint().listen()
-  print("established tunnel at: {}".format(tunnel.url()))
-  tunnel.forward_tcp("localhost:9000")
-  HTTPServer(('localhost',9000), HelloHandler).serve_forever()
-
-asyncio.run(create_tunnel())
+logging.basicConfig(level=logging.INFO)
+server = HTTPServer(("localhost",0), HelloHandler)
+ngrok.listen(server)
+server.serve_forever()

--- a/examples/ngrok-tcp.py
+++ b/examples/ngrok-tcp.py
@@ -1,21 +1,14 @@
 #!/usr/bin/env python
 
-import asyncio
-from http.server import HTTPServer, BaseHTTPRequestHandler
-import logging
-import io
-from ngrok import NgrokSessionBuilder, log_level
-import os
-import socket
-import socketserver
-import threading
-import time
+import asyncio, logging, ngrok, socketserver, threading
+from http.server import BaseHTTPRequestHandler
 
-UNIX_SOCKET = "/tmp/http.socket"
+logging.basicConfig(level=logging.INFO)
+pipe = ngrok.pipe_name()
 
 async def create_tunnel():
-  builder = NgrokSessionBuilder()
-  session = (await builder.authtoken_from_env()
+  # create session
+  session = (await ngrok.NgrokSessionBuilder().authtoken_from_env()
     .metadata("Online in One Line")
     .connect()
   )
@@ -29,8 +22,7 @@ async def create_tunnel():
     .metadata("example tunnel metadata from python")
     .listen()
   )
-  print("established tunnel at: {}".format(tunnel.url()))
-  await tunnel.forward_pipe(UNIX_SOCKET)
+  await tunnel.forward_pipe(pipe)
 
 class HelloHandler(BaseHTTPRequestHandler):
   def do_GET(self):
@@ -48,14 +40,6 @@ class UnixSocketHttpServer(socketserver.UnixStreamServer):
         request, client_address = super(UnixSocketHttpServer, self).get_request()
         return (request, ["local", 0])
 
-def start_unix_http_server():
-  if os.path.exists(UNIX_SOCKET):
-    os.remove(UNIX_SOCKET)
-  httpd = UnixSocketHttpServer((UNIX_SOCKET), HelloHandler)
-  thread = threading.Thread(target=httpd.serve_forever, daemon=True)
-  thread.start()
-
-start_unix_http_server()
-loop = asyncio.new_event_loop()
-loop.run_until_complete(create_tunnel())
-loop.close()
+httpd = UnixSocketHttpServer((pipe), HelloHandler)
+threading.Thread(target=httpd.serve_forever, daemon=True).start()
+asyncio.run(create_tunnel())

--- a/examples/uvicorn-test.py
+++ b/examples/uvicorn-test.py
@@ -1,40 +1,19 @@
 #!/usr/bin/env python
 
-import asyncio
-from uvicorn import Config, Server
-from ngrok import NgrokSessionBuilder
-import os
+import logging, ngrok, uvicorn
 
-UNIX_SOCKET = "/tmp/http.socket"
-if os.path.exists(UNIX_SOCKET):
-    os.remove(UNIX_SOCKET)
-
-# start tunnel
-async def create_tunnel():
-  session = await NgrokSessionBuilder().authtoken_from_env().connect()
-  tunnel = await session.http_endpoint().listen()
-  print("established tunnel at: {}".format(tunnel.url()))
-  await tunnel.forward_pipe(UNIX_SOCKET)
-
-loop = asyncio.new_event_loop()
-loop.create_task(create_tunnel())
-
-# start web server
 async def app(scope, receive, send):
   assert scope['type'] == 'http'
 
   await send({
     'type': 'http.response.start',
     'status': 200,
-    'headers': [
-      [b'content-type', b'text/plain'],
-    ],
+    'headers': [[b'content-type', b'text/plain']],
   })
   await send({
     'type': 'http.response.body',
     'body': b'Hello, world!',
   })
 
-# cannot pass in the loop instance like aiohttp allows
-server = Server(Config(app=app, uds=UNIX_SOCKET, loop="none"))
-loop.run_until_complete(server.serve())
+logging.basicConfig(level=logging.INFO)
+uvicorn.run(app=app, fd=ngrok.fd())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,17 @@ use tunnel_builder::{
     NgrokTlsTunnelBuilder,
 };
 
-use crate::logging::log_level;
+use crate::{
+    logging::log_level,
+    wrapper::{
+        default,
+        fd,
+        getsockname,
+        listen,
+        pipe_name,
+        werkzeug_develop,
+    },
+};
 
 pub mod http;
 pub mod logging;
@@ -34,6 +44,7 @@ pub mod tcp;
 pub mod tls;
 pub mod tunnel;
 pub mod tunnel_builder;
+pub mod wrapper;
 
 // A Python module implemented in Rust. The name of this function must match
 // the `lib.name` setting in the `Cargo.toml`, else Python will not be able to
@@ -42,7 +53,13 @@ pub mod tunnel_builder;
 /// The ngrok Agent SDK for Python
 #[pymodule]
 fn ngrok(py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(default, m)?)?;
+    m.add_function(wrap_pyfunction!(fd, m)?)?;
+    m.add_function(wrap_pyfunction!(getsockname, m)?)?;
+    m.add_function(wrap_pyfunction!(listen, m)?)?;
     m.add_function(wrap_pyfunction!(log_level, m)?)?;
+    m.add_function(wrap_pyfunction!(pipe_name, m)?)?;
+    m.add_function(wrap_pyfunction!(werkzeug_develop, m)?)?;
 
     m.add_class::<NgrokSessionBuilder>()?;
     m.add_class::<NgrokSession>()?;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -14,6 +14,7 @@ use crate::py_err;
 /// Set the log level for the bridge to Python logging.
 /// The log level defaults to INFO, it can be set to one of ERROR, WARN, INFO, DEBUG, or TRACE.
 #[pyfunction]
+#[pyo3(text_signature = "(level=\"INFO\")")]
 pub fn log_level(py: Python, level: Option<String>) -> PyResult<()> {
     let tracing_level = if let Some(level) = level {
         match level.to_uppercase().as_str() {

--- a/src/tunnel_builder.rs
+++ b/src/tunnel_builder.rs
@@ -55,7 +55,7 @@ macro_rules! make_tunnel_builder {
             }
 
             /// Begin listening for new connections on this tunnel.
-            pub fn listen<'a>(&self, py: Python<'a>, _bind: Option<bool>) -> PyResult<&'a PyAny> {
+            pub fn listen<'a>(&self, py: Python<'a>) -> PyResult<&'a PyAny> {
                 let session = self.session.lock().clone();
                 let tun = self.tunnel_builder.lock().clone();
                 pyo3_asyncio::tokio::future_into_py(

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,0 +1,235 @@
+use pyo3::{
+    intern,
+    pyfunction,
+    types::{
+        PyModule,
+        PyString,
+        PyTuple,
+    },
+    IntoPy,
+    Py,
+    PyAny,
+    PyResult,
+    Python,
+};
+
+use crate::py_err;
+
+/// Create a path name to use for pipe forwarding.
+/// This will be a file path in the temp directory on unix-like systems,
+/// or a named pipe on Windows. Files will be removed at program exit.
+#[pyfunction]
+pub fn pipe_name(py: Python) -> PyResult<Py<PyAny>> {
+    call_code(
+        py,
+        None,
+        r###"
+import atexit
+import logging
+import os
+import random
+import tempfile
+
+path = '\\\\.\\pipe\\ngrok_pipe' if os.name == 'nt' else \
+    "{}/tun-{}.sock".format(tempfile.gettempdir(), random.randrange(0,1000000))
+
+def delete_socket():
+    if os.path.exists(path):
+        logging.info('deleting {}'.format(path))
+        os.remove(path)
+
+def run(input=None):
+    atexit.register(delete_socket)
+    return path
+    "###,
+    )
+}
+
+/// Create a default HTTP tunnel. Optionally pass in a connected NgrokSession to use.
+///
+/// Returns the tunnel if no async loop is running, otherwise returns a Task to await with a tunnel result.
+#[pyfunction]
+pub fn default(py: Python, session: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
+    default_tunnel_with_return(py, session, "tunnel")
+}
+
+/// Create a default HTTP tunnel and get its file descriptor. Optionally pass in a connected NgrokSession to use.
+///
+/// Returns the file descriptor if no async loop is running, otherwise returns a Task to await with a file descriptor result.
+#[pyfunction]
+pub fn fd(py: Python, session: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
+    default_tunnel_with_return(py, session, "tunnel.fd")
+}
+
+/// Create a default HTTP tunnel and get its socket name. Optionally pass in a connected NgrokSession to use.
+///
+/// Returns the socket name if no async loop is running, otherwise returns a Task to await with a socket name result.
+#[pyfunction]
+pub fn getsockname(py: Python, session: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
+    default_tunnel_with_return(py, session, "tunnel.getsockname()")
+}
+
+fn default_tunnel_with_return(
+    py: Python,
+    session: Option<Py<PyAny>>,
+    return_str: &str,
+) -> PyResult<Py<PyAny>> {
+    loop_wrap(
+        py,
+        session,
+        &format!(
+            r###"
+    if input is None:
+        input = await NgrokSessionBuilder().authtoken_from_env().connect()
+    tunnel = await input.http_endpoint().listen()
+    return {return_str}
+    "###
+        ),
+    )
+}
+
+/// Create and return a listening default HTTP tunnel.
+/// Optionally pass in an object with at "server_address" attribute,
+/// such as a http.server.HTTPServer, and the tunnel will
+/// forward TCP to that server_address. Optionally also pass in a previously created tunnel.
+///
+/// Returns the created tunnel if no async loop is running, otherwise returns a Task to await with a tunnel result.
+#[pyfunction]
+pub fn listen(
+    py: Python,
+    server: Option<Py<PyAny>>,
+    tunnel: Option<Py<PyAny>>,
+) -> PyResult<Py<PyAny>> {
+    let mut forward = "".to_string();
+    if let Some(server) = server {
+        let server_address_attr = server.getattr(py, "server_address")?;
+        let address_type = server_address_attr.as_ref(py).get_type();
+
+        forward = if server_address_attr
+            .as_ref(py)
+            .is_instance(py.get_type::<PyTuple>())?
+        {
+            let address: &PyTuple = server_address_attr.downcast(py)?;
+            format!(
+                "input.forward_tcp('{}:{}')",
+                address.get_item(0)?,
+                address.get_item(1)?
+            )
+        } else if server_address_attr
+            .as_ref(py)
+            .is_instance(py.get_type::<PyString>())?
+        {
+            let address: &PyString = server_address_attr.downcast(py)?;
+            format!("input.forward_pipe('{address}')")
+        } else {
+            return Err(py_err(format!(
+                "Unhandled server_address type: {address_type}"
+            )));
+        };
+    }
+
+    loop_wrap(
+        py,
+        tunnel,
+        &format!(
+            r###"
+    if input is None:
+        session = await NgrokSessionBuilder().authtoken_from_env().connect()
+        input = await session.http_endpoint().listen()
+    {forward}
+    return input
+    "###
+        ),
+    )
+}
+
+/// Set the WERKZEUG_SERVER_FD environment variable with a file descriptor from a default HTTP tunnel.
+/// Also sets WERKZEUG_RUN_MAIN to "true" to engage the use of WERKZEUG_SERVER_FD.
+///
+/// Returns the created tunnel if no async loop is running, otherwise returns a Task to await with a tunnel result.
+#[pyfunction]
+pub fn werkzeug_develop(py: Python, tunnel: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
+    loop_wrap(
+        py,
+        tunnel,
+        r###"
+    if input is None:
+        session = await NgrokSessionBuilder().authtoken_from_env().connect()
+        input = await session.http_endpoint().listen()
+    os.environ["WERKZEUG_SERVER_FD"] = str(input.fd)
+    os.environ["WERKZEUG_RUN_MAIN"] = "true"
+    return input
+    "###,
+    )
+}
+
+/// Python wrapper to call the passed in work in an async context whether or not an async loop is running.
+fn loop_wrap(py: Python, input: Option<Py<PyAny>>, work: &str) -> PyResult<Py<PyAny>> {
+    let code = format!(
+        r###"
+import asyncio
+from ngrok import NgrokSessionBuilder
+import os
+
+async def wrap(input=None):
+{work}
+
+def run(input=None):
+    try:
+        running_loop = asyncio.get_running_loop()
+        return running_loop.create_task(wrap(input))
+    except RuntimeError:
+        pass
+
+    tunnel = asyncio.run(wrap(input))
+    return tunnel
+    "###
+    );
+
+    call_code(py, input, code.as_str())
+}
+
+/// Call the given code, returning the required 'retval' attribute from it.
+fn call_code(py: Python, input: Option<Py<PyAny>>, code: &str) -> PyResult<Py<PyAny>> {
+    let run = PyModule::from_code(py, code, "", "")?.getattr("run")?;
+
+    let res = match input {
+        Some(input) => {
+            let args = PyTuple::new(py, &[input]);
+            run.call1(args)?
+        }
+        None => run.call0()?,
+    };
+
+    Ok(res.into())
+}
+
+/// Create and bind a python localhost TCP socket.
+pub(crate) fn bound_default_tcp_socket(py: Python) -> PyResult<Py<PyAny>> {
+    let socket = PyModule::import(py, intern!(py, "socket"))?;
+    let sock_func = socket.getattr(intern!(py, "socket"))?;
+    let obj = sock_func.call0()?;
+    let bind = obj.getattr(intern!(py, "bind"))?;
+    let host: &PyAny = PyString::new(py, "localhost");
+    let port: &PyAny = 0u8.into_py(py).into_ref(py);
+    let address = PyTuple::new(py, [host, port]);
+    let args = PyTuple::new(py, [address]);
+    bind.call1(args)?;
+    let res = obj.into_py(py);
+    Ok(res)
+}
+
+/// Create and bind a python pipe socket.
+pub(crate) fn bound_default_pipe_socket(py: Python) -> PyResult<Py<PyAny>> {
+    let socket = PyModule::import(py, intern!(py, "socket"))?;
+    let sock_func = socket.getattr(intern!(py, "socket"))?;
+    let af_unix = socket.getattr(intern!(py, "AF_UNIX"))?;
+    let sock_args = PyTuple::new(py, [af_unix]);
+    let obj = sock_func.call1(sock_args)?;
+    let bind = obj.getattr(intern!(py, "bind"))?;
+    let address = pipe_name(py)?;
+    let args = PyTuple::new(py, &[address]);
+    bind.call1(args)?;
+    let res = obj.into_py(py);
+    Ok(res)
+}


### PR DESCRIPTION
The meat of this change is `tunnel.rs` which now has methods to spin up a python socket and proxy calls to it, and `wrapper.rs` which has some module-level helpers to set up default tunnels or link a tunnel to a web framework. The rest is tests and reduced size of examples.