### PR TITLE
add ca_cert, connection & heartbeat session configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,11 @@ jobs:
         id: decide
         run: |
           echo "github.ref: ${{ github.ref }}"
+          echo "github.repository: ${{ github.repository }}"
           echo "git log:"
           git log -1 --pretty=%B
 
-          if [ '${{ github.ref }}' == 'refs/heads/main' ] && git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$"; then
+          if [ '${{ github.ref }}' == 'refs/heads/main' ] && [ '${{ github.repository }}' == 'ngrok/ngrok-py' ] && git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$"; then
             echo "SHOULD_PUBLISH=true" >> $GITHUB_OUTPUT
           else
             echo "SHOULD_PUBLISH=false" >> $GITHUB_OUTPUT

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ name = "ngrok"
 crate-type = ["cdylib"]
 
 [dependencies]
+async-rustls = { version = "0.3.0" }
 async-trait = "0.1.59"
 bytes = "1.3.0"
 futures = "0.3.26"
@@ -19,6 +20,7 @@ pyo3 = { version = "0.18.1", features = ["abi3", "abi3-py37", "extension-module"
 pyo3-asyncio = { version = "0.18.0", features = ["attributes", "tokio-runtime"] }
 pyo3-log = { version = "0.8.1" }
 parking_lot = "0.12.1"
+rustls-pemfile = "1.0.1"
 tokio = { version = "1.23.0", features = ["sync"] }
 tracing = { version = "0.1.37", features = ["log", "log-always"] }
 

--- a/examples/ngrok-http-full.py
+++ b/examples/ngrok-http-full.py
@@ -28,9 +28,6 @@ def on_update(version, permit_major_version):
 def on_heartbeat(latency):
   print(f"heartbeat, latency: {latency} milliseconds")
 
-def on_connection(addr):
-  print(f"connecting, addr: {addr}")
-
 def on_disconnection(addr, error):
   print(f"connecting, addr: {addr} error: {error}")
 
@@ -43,7 +40,6 @@ async def create_tunnel():
     .handle_restart_command(on_restart)
     .handle_update_command(on_update)
     .handle_heartbeat(on_heartbeat)
-    .handle_connection(on_connection)
     .handle_disconnection(on_disconnection)
     .connect()
   )

--- a/examples/ngrok-http-full.py
+++ b/examples/ngrok-http-full.py
@@ -17,13 +17,22 @@ logging.basicConfig(level=logging.INFO, \
 # ngrok.log_level("TRACE")
 
 def on_stop():
-  print("on_stop")
+  print("stop command")
 
 def on_restart():
-  print("on_restart")
+  print("restart command")
 
 def on_update(version, permit_major_version):
-  print("on_update, version: {}, permit_major_version: {}".format(version, permit_major_version))
+  print(f"update command, version: {version}, permit_major_version: {permit_major_version}")
+
+def on_heartbeat(latency):
+  print(f"heartbeat, latency: {latency} milliseconds")
+
+def on_connection(addr):
+  print(f"connecting, addr: {addr}")
+
+def on_disconnection(addr, error):
+  print(f"connecting, addr: {addr} error: {error}")
 
 async def create_tunnel():
   # create session
@@ -33,6 +42,9 @@ async def create_tunnel():
     .handle_stop_command(on_stop)
     .handle_restart_command(on_restart)
     .handle_update_command(on_update)
+    .handle_heartbeat(on_heartbeat)
+    .handle_connection(on_connection)
+    .handle_disconnection(on_disconnection)
     .connect()
   )
   # create tunnel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,4 +32,5 @@ repository = "https://github.com/ngrok/ngrok-py"
 changelog = "https://github.com/ngrok/ngrok-py/blob/main/CHANGELOG.md"
 
 [build-system]
-requires = ["maturin"]
+requires = ["maturin>=0.14,<0.15"]
+build-backend = "maturin"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp==3.8.4
 Flask==2.2.3
 furo==2022.12.7
-maturin==0.14.15
+maturin==0.14.16
 pytest-xdist==3.2.0
 requests==2.28.2
 Sphinx==6.1.3

--- a/test/test.py
+++ b/test/test.py
@@ -393,26 +393,20 @@ class TestNgrok(unittest.IsolatedAsyncioTestCase):
     await tunnel4.close()
 
   async def test_connect_heartbeat_callbacks(self):
-    global conn_addr
     global disconn_addr
     global test_latency
     disconn_addr = None
     def on_heartbeat(latency):
       global test_latency
       test_latency = latency
-    def on_conn(addr):
-      global conn_addr
-      conn_addr = addr
     def on_disconn(addr, err):
       global disconn_addr
       disconn_addr = addr
     builder = ngrok.NgrokSessionBuilder()
     (builder
       .handle_heartbeat(on_heartbeat)
-      .handle_connection(on_conn)
       .handle_disconnection(on_disconn))
     await builder.connect()
-    self.assertTrue("ngrok" in conn_addr)
     self.assertTrue(test_latency > 0)
     self.assertEqual(None, disconn_addr)
 

--- a/test/test.py
+++ b/test/test.py
@@ -392,5 +392,29 @@ class TestNgrok(unittest.IsolatedAsyncioTestCase):
     await tunnel3.close()
     await tunnel4.close()
 
+  async def test_connect_heartbeat_callbacks(self):
+    global conn_addr
+    global disconn_addr
+    global test_latency
+    disconn_addr = None
+    def on_heartbeat(latency):
+      global test_latency
+      test_latency = latency
+    def on_conn(addr):
+      global conn_addr
+      conn_addr = addr
+    def on_disconn(addr, err):
+      global disconn_addr
+      disconn_addr = addr
+    builder = ngrok.NgrokSessionBuilder()
+    (builder
+      .handle_heartbeat(on_heartbeat)
+      .handle_connection(on_conn)
+      .handle_disconnection(on_disconn))
+    await builder.connect()
+    self.assertTrue("ngrok" in conn_addr)
+    self.assertTrue(test_latency > 0)
+    self.assertEqual(None, disconn_addr)
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Adding `ca_cert`, `handle_connection`, `handle_disconnection`, & `handle_heartbeat` on the python side. Similar to the nodejs change at: https://github.com/ngrok/ngrok-js/pull/25