### PR TITLE
Examples and workarounds for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,60 +1,70 @@
-all: install run
+# system python interpreter. used only to create virtual environment
+PY = python3
+VENV = .env
+BIN=$(VENV)/bin
 
-install: venv
-	: # Activate venv
-	. .env/bin/activate && pip install -r requirements.txt
+# make it work on windows too
+ifeq ($(OS), Windows_NT)
+	BIN=$(VENV)/Scripts
+	PY=python
+endif
+
+all: venv run
 
 venv:
 	: # Create venv if it doesn't exist
-	test -d venv || python3 -m venv .env
+	test -d $(VENV) || ($(PY) -m venv $(VENV) && $(BIN)/pip install -r requirements.txt)
 
-develop: install
-	. .env/bin/activate && maturin develop
+install:
+	. $(BIN)/activate && pip install -r requirements.txt
 
-build: install
-	. .env/bin/activate && maturin build
+develop: venv
+	. $(BIN)/activate && maturin develop
+
+build: venv
+	. $(BIN)/activate && maturin build
 
 run: develop
-	. .env/bin/activate && ./examples/ngrok-http-minimal.py
+	. $(BIN)/activate && ./examples/ngrok-http-minimal.py
 
 runaio: develop
-	. .env/bin/activate && python ./examples/aiohttp-test.py
+	. $(BIN)/activate && python ./examples/aiohttp-test.py
 
 runflask: develop
-	. .env/bin/activate && python ./examples/flask-test.py
+	. $(BIN)/activate && python ./examples/flask-test.py
 
 runfull: develop
-	. .env/bin/activate && ./examples/ngrok-http-full.py
+	. $(BIN)/activate && ./examples/ngrok-http-full.py
 
 runlabeled: develop
-	. .env/bin/activate && ./examples/ngrok-labeled.py
+	. $(BIN)/activate && ./examples/ngrok-labeled.py
 
 runtcp: develop
-	. .env/bin/activate && ./examples/ngrok-tcp.py
+	. $(BIN)/activate && ./examples/ngrok-tcp.py
 
 runtls: develop
-	. .env/bin/activate && ./examples/ngrok-tls.py
+	. $(BIN)/activate && ./examples/ngrok-tls.py
 
 runuvi: develop
-	. .env/bin/activate && python ./examples/uvicorn-test.py
+	. $(BIN)/activate && python ./examples/uvicorn-test.py
 
 # e.g.: make test=TestNgrok.test_gzip_tunnel test
 test: develop
-	. .env/bin/activate && python ./test/test.py $(test)
+	. $(BIN)/activate && python ./test/test.py $(test)
 
 # e.g.: make test=TestNgrok.test_gzip_tunnel testonly
 testonly:
-	. .env/bin/activate && python ./test/test.py $(test)
+	. $(BIN)/activate && python ./test/test.py $(test)
 
 # testfast is called by github workflow in ci.yml
 testfast: develop
-	. .env/bin/activate && py.test -n 4 ./test/test.py
+	. $(BIN)/activate && py.test -n 4 ./test/test.py
 
 testpublish:
-	. .env/bin/activate && maturin publish --repository testpypi
+	. $(BIN)/activate && maturin publish --repository testpypi
 
 docs: develop
-	. .env/bin/activate && sphinx-build -b html doc_source/ docs/
+	. $(BIN)/activate && sphinx-build -b html doc_source/ docs/
 
 clean:
-	rm -rf .env target/
+	rm -rf $(VENV) target/

--- a/examples/flask-test.py
+++ b/examples/flask-test.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-import flask, ngrok
+import flask, logging, ngrok, sys
 
+logging.basicConfig(level=logging.INFO)
 tunnel = ngrok.werkzeug_develop()
-print("tunnel established at: {}".format(tunnel.url()))
 
 if __name__ == "__main__":
   app = flask.Flask(__name__)

--- a/examples/ngrok-labeled.py
+++ b/examples/ngrok-labeled.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 
-import asyncio, logging, ngrok, socketserver, threading
-from http.server import BaseHTTPRequestHandler
-
-logging.basicConfig(level=logging.INFO)
-pipe = ngrok.pipe_name()
+import asyncio, logging, ngrok, os, socketserver, threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 async def create_tunnel():
   # create session
@@ -13,12 +10,10 @@ async def create_tunnel():
     .connect()
   )
   # create tunnel
-  tunnel = (await session.labeled_tunnel()
+  return (await session.labeled_tunnel()
     .label("edge", "edghts_<edge_id>")
     .metadata("example tunnel metadata from python")
-    .listen()
-  )
-  await tunnel.forward_pipe(pipe)
+    .listen())
 
 class HelloHandler(BaseHTTPRequestHandler):
   def do_GET(self):
@@ -30,12 +25,16 @@ class HelloHandler(BaseHTTPRequestHandler):
     self.end_headers()
     self.wfile.write(body)
 
-# Set up a unix socket wrapper around standard http server
-class UnixSocketHttpServer(socketserver.UnixStreamServer):
+httpd = ThreadingHTTPServer(('localhost',0), HelloHandler)
+if os.name != 'nt':
+  # Set up a unix socket wrapper around standard http server
+  class UnixSocketHttpServer(socketserver.UnixStreamServer):
     def get_request(self):
-        request, client_address = super(UnixSocketHttpServer, self).get_request()
-        return (request, ["local", 0])
+      request, client_address = super(UnixSocketHttpServer, self).get_request()
+      return (request, ["local", 0])
+  httpd = UnixSocketHttpServer((ngrok.pipe_name()), HelloHandler)
 
-httpd = UnixSocketHttpServer((pipe), HelloHandler)
-threading.Thread(target=httpd.serve_forever, daemon=True).start()
-asyncio.run(create_tunnel())
+logging.basicConfig(level=logging.INFO)
+tunnel = asyncio.run(create_tunnel())
+ngrok.listen(httpd, tunnel)
+httpd.serve_forever()

--- a/examples/ngrok-tcp.py
+++ b/examples/ngrok-tcp.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 
-import asyncio, logging, ngrok, socketserver, threading
-from http.server import BaseHTTPRequestHandler
-
-logging.basicConfig(level=logging.INFO)
-pipe = ngrok.pipe_name()
+import asyncio, logging, ngrok, os, socketserver, threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 async def create_tunnel():
   # create session
@@ -13,16 +10,14 @@ async def create_tunnel():
     .connect()
   )
   # create tunnel
-  tunnel = (await session.tcp_endpoint()
+  return (await session.tcp_endpoint()
     # .allow_cidr("0.0.0.0/0")
     # .deny_cidr("10.1.1.1/32")
     # .forwards_to("example python")
     # .proxy_proto("") # One of: "", "1", "2"
     # .remote_addr("<n>.tcp.ngrok.io:<p>")
     .metadata("example tunnel metadata from python")
-    .listen()
-  )
-  await tunnel.forward_pipe(pipe)
+    .listen())
 
 class HelloHandler(BaseHTTPRequestHandler):
   def do_GET(self):
@@ -34,12 +29,16 @@ class HelloHandler(BaseHTTPRequestHandler):
     self.end_headers()
     self.wfile.write(body)
 
-# Set up a unix socket wrapper around standard http server
-class UnixSocketHttpServer(socketserver.UnixStreamServer):
+httpd = ThreadingHTTPServer(('localhost',0), HelloHandler)
+if os.name != 'nt':
+  # Set up a unix socket wrapper around standard http server
+  class UnixSocketHttpServer(socketserver.UnixStreamServer):
     def get_request(self):
-        request, client_address = super(UnixSocketHttpServer, self).get_request()
-        return (request, ["local", 0])
+      request, client_address = super(UnixSocketHttpServer, self).get_request()
+      return (request, ["local", 0])
+  httpd = UnixSocketHttpServer((ngrok.pipe_name()), HelloHandler)
 
-httpd = UnixSocketHttpServer((pipe), HelloHandler)
-threading.Thread(target=httpd.serve_forever, daemon=True).start()
-asyncio.run(create_tunnel())
+logging.basicConfig(level=logging.INFO)
+tunnel = asyncio.run(create_tunnel())
+ngrok.listen(httpd, tunnel)
+httpd.serve_forever()

--- a/examples/uvicorn-test.py
+++ b/examples/uvicorn-test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-import logging, ngrok, uvicorn
+import asyncio, logging, ngrok, os, uvicorn
+logging.basicConfig(level=logging.INFO)
 
 async def app(scope, receive, send):
   assert scope['type'] == 'http'
@@ -15,5 +16,12 @@ async def app(scope, receive, send):
     'body': b'Hello, world!',
   })
 
-logging.basicConfig(level=logging.INFO)
+if os.name == 'nt': # windows
+  async def setup():
+    tunnel = await ngrok.default()
+    tunnel.forward_tcp('localhost:8000')
+  asyncio.run(setup())
+  uvicorn.run(app=app)
+  exit()
+
 uvicorn.run(app=app, fd=ngrok.fd())


### PR DESCRIPTION
Sprucing up for Windows usage:
- Examples all now work on Windows out of the box, sometimes requiring an `os.name` check so non-windows still get the benefit of unix sockets. Sadly Python named-pipe support on Windows barely exists, and isn't incorporated into any of these web frameworks.
- Pass `gettimeout` through the tunnel to the proxy socket.
- Implements `Iterable` on Windows so `aiohttp` will walk the one-element list and get back a pure Python proxy object so that it can be weak referenced, which the Windows `proactor` event loops requires. Pyo3 generated objects like our tunnels don't support weak references until ABI 3.9, but we support 3.7+.