### PR TITLE
consolidate tunnel wrappers, add session in storage

### DIFF
--- a/doc_source/index.rst
+++ b/doc_source/index.rst
@@ -10,11 +10,12 @@ API Reference
 =============
 
 .. toctree::
-   :caption: Sessions:
+   :caption: Tunnel and Sessions:
    :maxdepth: 1
 
    ngrok_session_builder
    ngrok_session
+   ngrok_tunnel
 
 .. toctree::
    :caption: Tunnel Builders:
@@ -24,15 +25,6 @@ API Reference
    ngrok_tcp_tunnel_builder
    ngrok_tls_tunnel_builder
    ngrok_labeled_tunnel_builder
-
-.. toctree::
-   :caption: Tunnels:
-   :maxdepth: 1
-
-   ngrok_http_tunnel
-   ngrok_tcp_tunnel
-   ngrok_tls_tunnel
-   ngrok_labeled_tunnel
 
 .. toctree::
    :caption: Module:

--- a/doc_source/ngrok_http_tunnel.rst
+++ b/doc_source/ngrok_http_tunnel.rst
@@ -1,7 +1,0 @@
-Ngrok HTTP Tunnel
-=====================================
-
-.. automodule:: ngrok
-   :members: NgrokHttpTunnel
-   :noindex:
-

--- a/doc_source/ngrok_tcp_tunnel.rst
+++ b/doc_source/ngrok_tcp_tunnel.rst
@@ -1,7 +1,0 @@
-Ngrok TCP Tunnel
-=====================================
-
-.. automodule:: ngrok
-   :members: NgrokTcpTunnel
-   :noindex:
-

--- a/doc_source/ngrok_tls_tunnel.rst
+++ b/doc_source/ngrok_tls_tunnel.rst
@@ -1,7 +1,0 @@
-Ngrok TLS Tunnel
-=====================================
-
-.. automodule:: ngrok
-   :members: NgrokTlsTunnel
-   :noindex:
-

--- a/doc_source/ngrok_tunnel.rst
+++ b/doc_source/ngrok_tunnel.rst
@@ -1,7 +1,7 @@
-Ngrok Labeled Tunnel
+Ngrok Tunnel
 =====================================
 
 .. automodule:: ngrok
-   :members: NgrokLabeledTunnel
+   :members: NgrokTunnel
    :noindex:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,7 @@ use session::{
     NgrokSessionBuilder,
 };
 use tracing::debug;
-use tunnel::{
-    NgrokHttpTunnel,
-    NgrokLabeledTunnel,
-    NgrokTcpTunnel,
-    NgrokTlsTunnel,
-};
+use tunnel::NgrokTunnel;
 use tunnel_builder::{
     NgrokHttpTunnelBuilder,
     NgrokLabeledTunnelBuilder,
@@ -64,13 +59,10 @@ fn ngrok(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<NgrokSessionBuilder>()?;
     m.add_class::<NgrokSession>()?;
 
-    m.add_class::<NgrokHttpTunnel>()?;
+    m.add_class::<NgrokTunnel>()?;
     m.add_class::<NgrokHttpTunnelBuilder>()?;
-    m.add_class::<NgrokLabeledTunnel>()?;
     m.add_class::<NgrokLabeledTunnelBuilder>()?;
-    m.add_class::<NgrokTcpTunnel>()?;
     m.add_class::<NgrokTcpTunnelBuilder>()?;
-    m.add_class::<NgrokTlsTunnel>()?;
     m.add_class::<NgrokTlsTunnelBuilder>()?;
 
     // turn on logging bridge by default, since user won't see unless they activate Python logging

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -55,10 +55,17 @@ use crate::{
 static SOCK_CELL: GILOnceCell<Py<PyDict>> = GILOnceCell::new();
 
 lazy_static! {
-    // tunnel references to be kept until explicit close to prevent python gc from dropping them.
+    // tunnel references to be kept until explicit close to prevent nodejs gc from dropping them.
     // the tunnel wrapper object, and the underlying tunnel, both have references to the Session
     // so the Session is safe from premature dropping.
-    static ref GLOBAL_TUNNELS: Mutex<HashMap<String,Arc<Mutex<dyn ExtendedTunnel>>>> = Mutex::new(HashMap::new());
+    static ref GLOBAL_TUNNELS: Mutex<HashMap<String,Arc<Storage>>> = Mutex::new(HashMap::new());
+}
+
+/// Stores the tunnel and session references to be kept until explicit close.
+struct Storage {
+    tunnel: Arc<Mutex<dyn ExtendedTunnel>>,
+    session: Arc<Mutex<Session>>,
+    url: Option<String>,
 }
 
 /// The TunnelExt cannot be turned into an object since it contains generics, so implementing
@@ -69,25 +76,31 @@ pub trait ExtendedTunnel: Tunnel {
     async fn fwd_pipe(&mut self, addr: String) -> core::result::Result<(), io::Error>;
 }
 
+/// An ngrok tunnel.
+#[pyclass]
+#[derive(Clone)]
+pub(crate) struct NgrokTunnel {
+    id: String,
+    forwards_to: String,
+    metadata: String,
+    url: Option<String>,
+    proto: Option<String>,
+    session: Session,
+    labels: HashMap<String, String>,
+}
+
 macro_rules! make_tunnel_type {
     // the common (non-labeled) branch
     ($(#[$outer:meta])* $wrapper:ident, $tunnel:tt, common) => {
 
         $(#[$outer])*
-        #[pyclass]
         #[allow(dead_code)]
         pub(crate) struct $wrapper {
-            id: String,
-            forwards_to: String,
-            metadata: String,
-            url: String,
-            proto: String,
-            session: Session,
         }
 
         #[allow(dead_code)]
         impl $wrapper {
-            pub(crate) async fn new(session: Session, raw_tunnel: $tunnel) -> Self {
+            pub(crate) async fn new_tunnel(session: Session, raw_tunnel: $tunnel) -> NgrokTunnel {
                 let id = raw_tunnel.id().to_string();
                 let forwards_to = raw_tunnel.forwards_to().to_string();
                 let metadata = raw_tunnel.metadata().to_string();
@@ -95,29 +108,20 @@ macro_rules! make_tunnel_type {
                 let proto = raw_tunnel.proto().to_string();
                 info!("Created tunnel {id:?} with url {url:?}");
                 // keep a tunnel reference until an explicit call to close to prevent python gc dropping it
-                GLOBAL_TUNNELS.lock().await.insert(id.clone(), Arc::new(Mutex::new(raw_tunnel)));
-                $wrapper {
+                GLOBAL_TUNNELS.lock().await.insert(id.clone(), Arc::new(Storage {
+                    tunnel: Arc::new(Mutex::new(raw_tunnel)),
+                    session: Arc::new(Mutex::new(session.clone())),
+                    url: Some(url.clone()),
+                }));
+                NgrokTunnel {
                     id,
                     forwards_to,
                     metadata,
-                    url,
-                    proto,
+                    url: Some(url),
+                    proto: Some(proto),
                     session,
+                    labels: HashMap::new(),
                 }
-            }
-        }
-
-        #[pymethods]
-        #[allow(dead_code)]
-        impl $wrapper {
-            /// The URL that this tunnel backs.
-            pub fn url(&self) -> String {
-                self.url.clone()
-            }
-
-            /// The protocol of the endpoint that this tunnel backs.
-            pub fn proto(&self) -> String {
-                self.proto.clone()
             }
         }
 
@@ -127,42 +131,33 @@ macro_rules! make_tunnel_type {
     // the labeled branch
     ($(#[$outer:meta])* $wrapper:ident, $tunnel:tt, label) => {
         $(#[$outer])*
-        #[pyclass]
         #[allow(dead_code)]
         pub(crate) struct $wrapper {
-            id: String,
-            forwards_to: String,
-            metadata: String,
-            labels: HashMap<String,String>,
-            session: Session,
         }
 
         #[allow(dead_code)]
         impl $wrapper {
-            pub(crate) async fn new(session: Session, raw_tunnel: $tunnel) -> Self {
+            pub(crate) async fn new_tunnel(session: Session, raw_tunnel: $tunnel) -> NgrokTunnel {
                 let id = raw_tunnel.id().to_string();
                 let forwards_to = raw_tunnel.forwards_to().to_string();
                 let metadata = raw_tunnel.metadata().to_string();
                 let labels = raw_tunnel.labels().clone();
                 info!("Created tunnel {id:?} with labels {labels:?}");
                 // keep a tunnel reference until an explicit call to close to prevent python gc dropping it
-                GLOBAL_TUNNELS.lock().await.insert(id.clone(), Arc::new(Mutex::new(raw_tunnel)));
-                $wrapper {
+                GLOBAL_TUNNELS.lock().await.insert(id.clone(), Arc::new(Storage {
+                    tunnel: Arc::new(Mutex::new(raw_tunnel)),
+                    session: Arc::new(Mutex::new(session.clone())),
+                    url: None,
+                }));
+                NgrokTunnel {
                     id,
                     forwards_to,
                     metadata,
                     labels,
                     session,
+                    url: None,
+                    proto: None,
                 }
-            }
-        }
-
-        #[pymethods]
-        #[allow(dead_code)]
-        impl $wrapper {
-            /// The labels this tunnel was started with.
-            pub fn labels(&self) -> HashMap<String, String> {
-                self.labels.clone()
             }
         }
 
@@ -180,228 +175,206 @@ macro_rules! make_tunnel_type {
                 self.forward_pipe(addr).await
             }
         }
-
-        #[pymethods]
-        #[allow(dead_code)]
-        impl $wrapper {
-            /// Returns a tunnel's unique ID.
-            pub fn id(&self) -> String {
-                self.id.clone()
-            }
-
-            /// Returns a human-readable string presented in the ngrok dashboard
-            /// and the Tunnels API. Use the [HttpTunnelBuilder::forwards_to],
-            /// [TcpTunnelBuilder::forwards_to], etc. to set this value
-            /// explicitly.
-            pub fn forwards_to(&self) -> String {
-                self.forwards_to.clone()
-            }
-
-            /// Returns the arbitrary metadata string for this tunnel.
-            pub fn metadata(&self) -> String {
-                self.metadata.clone()
-            }
-
-            /// Forward incoming tunnel connections to the provided TCP address.
-            pub fn forward_tcp<'a>(&self, py: Python<'a>, addr: String) -> PyResult<&'a PyAny> {
-                let id = self.id.clone();
-                pyo3_asyncio::tokio::future_into_py(
-                    py,
-                    async move {
-                        info!("Tunnel {id:?} TCP forwarding to {addr:?}");
-
-                        // we must clone the Arc before locking so we have a local reference
-                        // to the mutex to unlock if this struct is dropped.
-                        let arc = GLOBAL_TUNNELS.lock().await
-                            .get(&id)
-                            .ok_or(py_err("Tunnel is no longer running"))?
-                            .clone(); // required clone
-
-                        // doing this as a seperate statement so the GLOBAL_TUNNELS lock is dropped
-                        let res = arc
-                            .lock()
-                            .await
-                            .fwd_tcp(addr)
-                            .await
-                            .map_err(|e| py_err(format!("cannot forward tcp: {e:?}")));
-                        debug!("forward_tcp returning");
-                        res
-                    }
-                )
-            }
-
-            /// Forward incoming tunnel connections to the provided file socket path.
-            /// On Linux/Darwin addr can be a unix domain socket path, e.g. "/tmp/ngrok.sock"
-            /// On Windows addr can be a named pipe, e.e. "\\\\.\\pipe\\an_ngrok_pipe"
-            pub fn forward_pipe<'a>(&self, py: Python<'a>, addr: String) -> PyResult<&'a PyAny> {
-                let id = self.id.clone();
-                pyo3_asyncio::tokio::future_into_py(
-                    py,
-                    async move {
-                        info!("Tunnel {id:?} Pipe forwarding to {addr:?}");
-
-                        // we must clone the Arc before locking so we have a local reference
-                        // to the mutex to unlock if this struct is dropped.
-                        let arc = GLOBAL_TUNNELS.lock().await
-                            .get(&id)
-                            .ok_or(py_err("Tunnel is no longer running"))?
-                            .clone(); // required clone
-
-                        // doing this as a seperate statement so the GLOBAL_TUNNELS lock is dropped
-                        let res = arc
-                            .lock()
-                            .await
-                            .fwd_pipe(addr)
-                            .await
-                            .map_err(|e| py_err(format!("cannot forward pipe: {e:?}")));
-                        debug!("forward_pipe returning");
-                        res
-                    }
-                )
-            }
-
-            /// Close the tunnel.
-            ///
-            /// This is an RPC call that must be `.await`ed.
-            /// It is equivalent to calling `Session::close_tunnel` with this
-            /// tunnel's ID.
-            pub fn close<'a>(&self, py: Python<'a>) -> PyResult<&'a PyAny> {
-                let session = self.session.clone();
-                let id = self.id.clone();
-                pyo3_asyncio::tokio::future_into_py(
-                    py,
-                    async move {
-                        debug!("{} closing, id: {id:?}", stringify!($wrapper));
-
-                        // we may not be able to lock our reference to the tunnel due to the forward_* calls which
-                        // continuously accept-loop while the tunnel is active, so calling close on the Session.
-                        let res = session.close_tunnel(id.clone())
-                            .await
-                            .map_err(|e| py_err(format!("error closing tunnel: {e:?}")));
-
-                        // drop our internal reference to the tunnel after awaiting close
-                        remove_global_tunnel(&id).await?;
-
-                        res
-                    }
-                )
-            }
-        }
-
-        // Methods designed to act like a native socket
-        #[pymethods]
-        #[allow(dead_code)]
-        impl $wrapper {
-            // for aiohttp case, proxy calls to socket
-            #[getter]
-            pub fn get_family(&self, py: Python) -> PyResult<Py<PyAny>> {
-                self.get_sock_attr(py, intern!(py, "family"))
-            }
-
-            pub fn getsockname(&self, py: Python) -> PyResult<Py<PyAny>> {
-                self.get_sock_attr(py, intern!(py, "getsockname"))?.call0(py)
-            }
-
-            #[getter]
-            pub fn get_type(&self, py: Python) -> PyResult<Py<PyAny>> {
-                self.get_sock_attr(py, intern!(py, "type"))
-            }
-
-            pub fn setblocking(&self, py: Python, blocking: bool) -> PyResult<Py<PyAny>> {
-                let args = PyTuple::new(py, &[blocking]);
-                self.get_sock_attr(py, intern!(py, "setblocking"))?.call1(py, args)
-            }
-
-            pub fn fileno(&self, py: Python) -> PyResult<Py<PyAny>> {
-                self.get_sock_attr(py, intern!(py, "fileno"))?.call0(py)
-            }
-
-            pub fn accept(&self, py: Python) -> PyResult<Py<PyAny>> {
-                self.get_sock_attr(py, intern!(py, "accept"))?.call0(py)
-            }
-
-            pub fn gettimeout(&self, py: Python) -> PyResult<Py<PyAny>> {
-                self.get_sock_attr(py, intern!(py, "gettimeout"))?.call0(py)
-            }
-
-            pub fn listen(&self, py: Python, backlog: i32, listen_attr: Option<&str>) -> PyResult<Py<PyAny>> {
-                // call listen on socket
-                let args = PyTuple::new(py, &[backlog]);
-                let listen_string = PyString::new(py, listen_attr.unwrap_or("listen"));
-                let result = self.get_sock_attr(py, listen_string)?.call1(py, args);
-
-                // set up forwarding depending on socket type
-                let sockname = self.getsockname(py)?;
-                let socket = PyModule::import(py, "socket")?;
-                // windows does not have AF_UNIX enum at all
-                let af_unix = socket.getattr(intern!(py, "AF_UNIX"));
-                if let Ok(af_unix) = af_unix {
-                    if self.get_family(py)?.as_ref(py).eq(af_unix)? {
-                        // pipe
-                        let sockname_str: &PyString = sockname.downcast(py)?;
-                        self.forward_pipe(py, sockname_str.to_string())?;
-                        return result;
-                    }
-                }
-                // fallback to tcp
-                let sockname_tuple: &PyTuple = sockname.downcast(py)?;
-                self.forward_tcp(py, format!("localhost:{}", sockname_tuple.get_item(1)?))?;
-                result
-            }
-
-            // For uvicorn case, generate a file descriptor for a listening socket
-            #[getter]
-            pub fn get_fd(&self, py: Python) -> PyResult<Py<PyAny>> {
-                self.listen(py, 0, None)?;
-                self.fileno(py)
-            }
-
-            // Get or create the python socket to use for this tunnel, and return an attribute of it.
-            fn get_sock_attr(&self, py: Python, attr: &PyString) -> PyResult<Py<PyAny>> {
-                self.get_sock(py)?.getattr(py, attr)
-            }
-
-            fn get_sock(&self, py: Python) -> PyResult<Py<PyAny>> {
-                let map: &PyDict = SOCK_CELL.get_or_init(py, || PyDict::new(py).into()).extract(py)?;
-                let maybe_socket = map.get_item(&self.id);
-                Ok(match maybe_socket {
-                    Some(s) => s.into_py(py),
-                    None => {
-                        // try pipe first, fall back to tcp
-                        let res = match bound_default_pipe_socket(py) {
-                            Ok(res) => res,
-                            Err(error) => {
-                                debug!("error binding to pipe: {}", error);
-                                bound_default_tcp_socket(py)?
-                            }
-                        };
-                        map.set_item(self.id.clone(), res.clone())?;
-                        res
-                    }
-                })
-            }
-
-            // Fulfill the iterator protocol so aiohttp will grab the wrap object.
-            // This prevents the windows proactor framework from trying to use a weakref
-            // directly to the rust tunnel, which is not supported until ABI 3.9.
-            #[cfg(target_os = "windows")]
-            fn __iter__(self_: PyRef<'_, Self>, py: Python) -> PyResult<Py<Iter>> {
-                // Wrap self in a native python object to support weakref
-                let burrito = wrap_object(py, self_.into_py(py))?;
-                let iter = Iter {
-                    inner: vec![burrito].into_iter(),
-                };
-                Py::new(py, iter)
-            }
-        }
-
-        #[allow(unused_mut)]
-        impl Drop for $wrapper {
-            fn drop(&mut self) {
-                debug!("{} finalize, id: {}", stringify!($wrapper), self.id);
-            }
-        }
     };
+}
+
+#[pymethods]
+#[allow(dead_code)]
+impl NgrokTunnel {
+    /// Returns a tunnel's unique ID.
+    pub fn id(&self) -> String {
+        self.id.clone()
+    }
+
+    /// The URL that this tunnel backs.
+    pub fn url(&self) -> Option<String> {
+        self.url.clone()
+    }
+
+    /// The protocol of the endpoint that this tunnel backs.
+    pub fn proto(&self) -> Option<String> {
+        self.proto.clone()
+    }
+
+    /// The labels this tunnel was started with.
+    pub fn labels(&self) -> HashMap<String, String> {
+        self.labels.clone()
+    }
+
+    /// Returns a human-readable string presented in the ngrok dashboard
+    /// and the Tunnels API. Use the [HttpTunnelBuilder::forwards_to],
+    /// [TcpTunnelBuilder::forwards_to], etc. to set this value
+    /// explicitly.
+    pub fn forwards_to(&self) -> String {
+        self.forwards_to.clone()
+    }
+
+    /// Returns the arbitrary metadata string for this tunnel.
+    pub fn metadata(&self) -> String {
+        self.metadata.clone()
+    }
+
+    /// Forward incoming tunnel connections to the provided TCP address.
+    pub fn forward_tcp<'a>(&self, py: Python<'a>, addr: String) -> PyResult<&'a PyAny> {
+        let id = self.id.clone();
+        pyo3_asyncio::tokio::future_into_py(py, async move { forward_tcp(&id, addr).await })
+    }
+
+    /// Forward incoming tunnel connections to the provided file socket path.
+    /// On Linux/Darwin addr can be a unix domain socket path, e.g. "/tmp/ngrok.sock"
+    /// On Windows addr can be a named pipe, e.e. "\\\\.\\pipe\\an_ngrok_pipe"
+    pub fn forward_pipe<'a>(&self, py: Python<'a>, addr: String) -> PyResult<&'a PyAny> {
+        let id = self.id.clone();
+        pyo3_asyncio::tokio::future_into_py(py, async move { forward_pipe(&id, addr).await })
+    }
+
+    /// Close the tunnel.
+    ///
+    /// This is an RPC call that must be `.await`ed.
+    /// It is equivalent to calling `Session::close_tunnel` with this
+    /// tunnel's ID.
+    pub fn close<'a>(&self, py: Python<'a>) -> PyResult<&'a PyAny> {
+        let session = self.session.clone();
+        let id = self.id.clone();
+        pyo3_asyncio::tokio::future_into_py(py, async move {
+            debug!("{} closing, id: {id:?}", stringify!($wrapper));
+
+            // we may not be able to lock our reference to the tunnel due to the forward_* calls which
+            // continuously accept-loop while the tunnel is active, so calling close on the Session.
+            let res = session
+                .close_tunnel(id.clone())
+                .await
+                .map_err(|e| py_err(format!("error closing tunnel: {e:?}")));
+
+            // drop our internal reference to the tunnel after awaiting close
+            remove_global_tunnel(&id).await?;
+
+            res
+        })
+    }
+}
+
+// Methods designed to act like a native socket
+#[pymethods]
+#[allow(dead_code)]
+impl NgrokTunnel {
+    // for aiohttp case, proxy calls to socket
+    #[getter]
+    pub fn get_family(&self, py: Python) -> PyResult<Py<PyAny>> {
+        self.get_sock_attr(py, intern!(py, "family"))
+    }
+
+    pub fn getsockname(&self, py: Python) -> PyResult<Py<PyAny>> {
+        self.get_sock_attr(py, intern!(py, "getsockname"))?
+            .call0(py)
+    }
+
+    #[getter]
+    pub fn get_type(&self, py: Python) -> PyResult<Py<PyAny>> {
+        self.get_sock_attr(py, intern!(py, "type"))
+    }
+
+    pub fn setblocking(&self, py: Python, blocking: bool) -> PyResult<Py<PyAny>> {
+        let args = PyTuple::new(py, [blocking]);
+        self.get_sock_attr(py, intern!(py, "setblocking"))?
+            .call1(py, args)
+    }
+
+    pub fn fileno(&self, py: Python) -> PyResult<Py<PyAny>> {
+        self.get_sock_attr(py, intern!(py, "fileno"))?.call0(py)
+    }
+
+    pub fn accept(&self, py: Python) -> PyResult<Py<PyAny>> {
+        self.get_sock_attr(py, intern!(py, "accept"))?.call0(py)
+    }
+
+    pub fn gettimeout(&self, py: Python) -> PyResult<Py<PyAny>> {
+        self.get_sock_attr(py, intern!(py, "gettimeout"))?.call0(py)
+    }
+
+    pub fn listen(
+        &self,
+        py: Python,
+        backlog: i32,
+        listen_attr: Option<&str>,
+    ) -> PyResult<Py<PyAny>> {
+        // call listen on socket
+        let args = PyTuple::new(py, [backlog]);
+        let listen_string = PyString::new(py, listen_attr.unwrap_or("listen"));
+        let result = self.get_sock_attr(py, listen_string)?.call1(py, args);
+
+        // set up forwarding depending on socket type
+        let sockname = self.getsockname(py)?;
+        let socket = PyModule::import(py, "socket")?;
+        // windows does not have AF_UNIX enum at all
+        let af_unix = socket.getattr(intern!(py, "AF_UNIX"));
+        if let Ok(af_unix) = af_unix {
+            if self.get_family(py)?.as_ref(py).eq(af_unix)? {
+                // pipe
+                let sockname_str: &PyString = sockname.downcast(py)?;
+                self.forward_pipe(py, sockname_str.to_string())?;
+                return result;
+            }
+        }
+        // fallback to tcp
+        let sockname_tuple: &PyTuple = sockname.downcast(py)?;
+        self.forward_tcp(py, format!("localhost:{}", sockname_tuple.get_item(1)?))?;
+        result
+    }
+
+    // For uvicorn case, generate a file descriptor for a listening socket
+    #[getter]
+    pub fn get_fd(&self, py: Python) -> PyResult<Py<PyAny>> {
+        self.listen(py, 0, None)?;
+        self.fileno(py)
+    }
+
+    // Get or create the python socket to use for this tunnel, and return an attribute of it.
+    fn get_sock_attr(&self, py: Python, attr: &PyString) -> PyResult<Py<PyAny>> {
+        self.get_sock(py)?.getattr(py, attr)
+    }
+
+    fn get_sock(&self, py: Python) -> PyResult<Py<PyAny>> {
+        let map: &PyDict = SOCK_CELL
+            .get_or_init(py, || PyDict::new(py).into())
+            .extract(py)?;
+        let maybe_socket = map.get_item(&self.id);
+        Ok(match maybe_socket {
+            Some(s) => s.into_py(py),
+            None => {
+                // try pipe first, fall back to tcp
+                let res = match bound_default_pipe_socket(py) {
+                    Ok(res) => res,
+                    Err(error) => {
+                        debug!("error binding to pipe: {}", error);
+                        bound_default_tcp_socket(py)?
+                    }
+                };
+                map.set_item(self.id.clone(), res.clone())?;
+                res
+            }
+        })
+    }
+
+    // Fulfill the iterator protocol so aiohttp will grab the wrap object.
+    // This prevents the windows proactor framework from trying to use a weakref
+    // directly to the rust tunnel, which is not supported until ABI 3.9.
+    #[cfg(target_os = "windows")]
+    fn __iter__(self_: PyRef<'_, Self>, py: Python) -> PyResult<Py<Iter>> {
+        // Wrap self in a native python object to support weakref
+        let burrito = wrap_object(py, self_.into_py(py))?;
+        let iter = Iter {
+            inner: vec![burrito].into_iter(),
+        };
+        Py::new(py, iter)
+    }
+}
+
+#[allow(unused_mut)]
+impl Drop for NgrokTunnel {
+    fn drop(&mut self) {
+        debug!("NgrokTunnel finalize, id: {}", self.id);
+    }
 }
 
 make_tunnel_type! {
@@ -419,6 +392,45 @@ make_tunnel_type! {
 make_tunnel_type! {
     /// A labeled ngrok tunnel.
     NgrokLabeledTunnel, LabeledTunnel, label
+}
+
+pub async fn forward_tcp(id: &String, addr: String) -> PyResult<()> {
+    info!("Tunnel {id:?} TCP forwarding to {addr:?}");
+    let res = get_storage_by_id(id)
+        .await?
+        .tunnel
+        .lock()
+        .await
+        .fwd_tcp(addr)
+        .await
+        .map_err(|e| py_err(format!("cannot forward tcp: {e:?}")));
+    debug!("forward_tcp returning");
+    res
+}
+
+pub async fn forward_pipe(id: &String, addr: String) -> PyResult<()> {
+    info!("Tunnel {id:?} Pipe forwarding to {addr:?}");
+    let res = get_storage_by_id(id)
+        .await?
+        .tunnel
+        .lock()
+        .await
+        .fwd_pipe(addr)
+        .await
+        .map_err(|e| py_err(format!("cannot forward pipe: {e:?}")));
+    debug!("forward_pipe returning");
+    res
+}
+
+async fn get_storage_by_id(id: &String) -> PyResult<Arc<Storage>> {
+    // we must clone the Arc before any locking so there is a local reference
+    // to the mutex to unlock if the tunnel wrapper struct is dropped.
+    Ok(GLOBAL_TUNNELS
+        .lock()
+        .await
+        .get(id)
+        .ok_or(py_err("Tunnel is no longer running"))?
+        .clone()) // required clone
 }
 
 /// Delete any reference to the tunnel id
@@ -440,6 +452,34 @@ pub(crate) async fn remove_global_tunnel(id: &String) -> PyResult<()> {
         }
         Ok(())
     })
+}
+
+/// Close a tunnel with the given url, or all tunnels if no url is defined.
+#[allow(dead_code)]
+pub(crate) async fn close_url(url: Option<String>) -> PyResult<()> {
+    let mut close_ids: Vec<String> = vec![];
+    let tunnels = GLOBAL_TUNNELS.lock().await;
+    for (id, storage) in tunnels.iter() {
+        debug!("tunnel: {}", id);
+        if url.as_ref().is_none() || url == storage.url {
+            debug!("closing tunnel: {}", id);
+            storage
+                .session
+                .lock()
+                .await
+                .close_tunnel(id)
+                .await
+                .map_err(|e| py_err(format!("error closing tunnel: {e:?}")))?;
+            close_ids.push(id.clone());
+        }
+    }
+    drop(tunnels); // unlock GLOBAL_TUNNELS
+
+    // remove references entirely
+    for id in close_ids {
+        remove_global_tunnel(&id).await?;
+    }
+    Ok(())
 }
 
 // Helper class to implement the iterator protocol for tunnel sockets.

--- a/src/tunnel_builder.rs
+++ b/src/tunnel_builder.rs
@@ -68,7 +68,7 @@ macro_rules! make_tunnel_builder {
 
                         // create the wrapping tunnel object via its async new()
                         match result {
-                            Ok(raw_tun) => Ok($tunnel::new(session, raw_tun).await),
+                            Ok(raw_tun) => Ok($tunnel::new_tunnel(session, raw_tun).await),
                             Err(val) => Err(val),
                         }
                     },


### PR DESCRIPTION
Mostly all changes are in `tunnel.rs`, this consolidates from 4 tunnel objects to just 1, since the type-safety is really at the builder level, this makes for a simpler interface for the `connect` api that is coming, and for users. Other changes are just doc source and updating the struct list in `lib.rs`.