### PR TITLE
add ngrok.connect(options)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,12 @@ run: develop
 run-aio: develop examples-install
 	. $(BIN)/activate && python ./examples/aiohttp-ngrok.py
 
+run-connect-full: develop
+	. $(BIN)/activate && python ./examples/ngrok-connect-full.py
+
+run-connect-minimal: develop
+	. $(BIN)/activate && python ./examples/ngrok-connect-minimal.py
+
 run-django: develop examples-install
 	. $(BIN)/activate && python ./examples/django-single-file.py
 

--- a/doc_source/module.rst
+++ b/doc_source/module.rst
@@ -2,6 +2,6 @@ Ngrok Module
 =====================================
 
 .. automodule:: ngrok
-   :members: default, fd, getsockname, listen, log_level, pipe_name, werkzeug_develop
+   :members: connect, default, fd, getsockname, listen, log_level, pipe_name, werkzeug_develop
    :noindex:
 

--- a/examples/ngrok-connect-full.py
+++ b/examples/ngrok-connect-full.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import logging, ngrok, os
+import asyncio
+
+class HelloHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = bytes("Hello", "utf-8")
+        self.protocol_version = "HTTP/1.1"
+        self.send_response(200)
+        self.send_header("Content-Length", len(body))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def load_file(name):
+    with open("examples/{}".format(name), "r") as crt:
+        return bytearray(crt.read().encode())
+
+
+logging.basicConfig(level=logging.INFO)
+server = HTTPServer(("localhost", 8080), HelloHandler)
+tunnel = ngrok.connect(
+    # session configuration
+    addr="localhost:8080",
+    # authtoken="<authtoken>",
+    authtoken_from_env=True,
+    session_metadata="Online in One Line",
+    # tunnel configuration
+    basic_auth=["ngrok:online1line"],
+    circuit_breaker=0.1,
+    compression=True,
+    # domain="<domain>",
+    ip_restriction_allow_cidrs="0.0.0.0/0",
+    ip_restriction_deny_cidrs="10.1.1.1/32",
+    metadata="example tunnel metadata from nodejs",
+    # mutual_tls_cas=load_file("ca.crt"),
+    # oauth_provider="google",
+    # oauth_allow_domains=["<domain>"],
+    # oauth_allow_emails=["<email>"],
+    # oauth_scopes=["<scope>"],
+    # oidc_issuer_url="<url>",
+    # oidc_client_id="<id>",
+    # oidc_client_secret="<secret>",
+    # oidc_allow_domains=["<domain>"],
+    # oidc_allow_emails=["<email>"],
+    # oidc_scopes=["<scope>"],
+    proxy_proto="", # One of: "", "1", "2"
+    request_header_remove="X-Req-Nope",
+    response_header_remove="X-Res-Nope",
+    request_header_add="X-Req-Yup:true",
+    response_header_add="X-Res-Yup:true",
+    schemes=["HTTPS"],
+    # verify_webhook_provider="twilio",
+    # verify_webhook_secret="asdf",
+    # websocket_tcp_converter=True,
+)
+server.serve_forever()

--- a/examples/ngrok-connect-minimal.py
+++ b/examples/ngrok-connect-minimal.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import logging, ngrok, os
+import asyncio
+
+class HelloHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = bytes("Hello", "utf-8")
+        self.protocol_version = "HTTP/1.1"
+        self.send_response(200)
+        self.send_header("Content-Length", len(body))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+logging.basicConfig(level=logging.INFO)
+server = HTTPServer(("localhost", 8080), HelloHandler)
+tunnel = ngrok.connect("localhost:8080", authtoken_from_env=True)
+server.serve_forever()

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,0 +1,391 @@
+use lazy_static::lazy_static;
+use pyo3::{
+    pyfunction,
+    types::{
+        PyBool,
+        PyByteArray,
+        PyDict,
+        PyFloat,
+        PyInt,
+        PyList,
+        PyString,
+    },
+    IntoPy,
+    Py,
+    PyAny,
+    PyCell,
+    PyDowncastError,
+    PyErr,
+    PyObject,
+    PyResult,
+    Python,
+};
+use tokio::sync::Mutex;
+
+use crate::{
+    py_err,
+    session::{
+        NgrokSession,
+        NgrokSessionBuilder,
+    },
+    tunnel::{
+        self,
+        NgrokTunnel,
+    },
+    tunnel_builder::{
+        NgrokHttpTunnelBuilder,
+        NgrokLabeledTunnelBuilder,
+        NgrokTcpTunnelBuilder,
+        NgrokTlsTunnelBuilder,
+    },
+    wrapper,
+};
+
+lazy_static! {
+    // Save a user-facing NgrokSession to use for connect use cases
+    pub(crate) static ref SESSION: Mutex<Option<NgrokSession>> = Mutex::new(None);
+}
+
+/// Single string configuration
+macro_rules! plumb {
+    ($builder:tt, $self:tt, $config:tt, $name:tt) => {
+        plumb!($builder, $self, $config, $name, $name)
+    };
+    ($builder:tt, $self:tt, $config:tt, $name:tt, $config_name:tt) => {
+        if let Some(v) = $config.get_item(stringify!($config_name)) {
+            $builder::$name($self.borrow_mut(), get_string(v)?);
+        }
+    };
+}
+
+/// Boolean configuration
+macro_rules! plumb_bool {
+    ($builder:tt, $self:tt, $config:tt, $name:tt) => {
+        plumb_bool!($builder, $self, $config, $name, $name)
+    };
+    ($builder:tt, $self:tt, $config:tt, $name:tt, $config_name:tt) => {
+        if let Some(v) = $config.get_item(stringify!($config_name)) {
+            if get_bool(v)? {
+                $builder::$name($self.borrow_mut());
+            }
+        }
+    };
+}
+
+/// Vector configuration
+macro_rules! plumb_vec {
+    ($builder:tt, $self:tt, $config:tt, $name:tt) => {
+        plumb_vec!($builder, $self, $config, $name, $name)
+    };
+    ($builder:tt, $self:tt, $config:tt, $name:tt, $config_name:tt) => {
+        if let Some(v) = $config.get_item(stringify!($config_name)) {
+            for val in get_list(v)? {
+                $builder::$name($self.borrow_mut(), get_string(val)?);
+            }
+        }
+    };
+    ($builder:tt, $self:tt, $config:tt, $name:tt, $config_name:tt, vecu8) => {
+        if let Some(v) = $config.get_item(stringify!($config_name)) {
+            for val in get_list(v)? {
+                $builder::$name($self.borrow_mut(), get_byte_array(val)?);
+            }
+        }
+    };
+    ($builder:tt, $self:tt, $config:tt, $name:tt, $config_name:tt, $split:tt) => {
+        if let Some(v) = $config.get_item(stringify!($config_name)) {
+            for val in get_list(v)? {
+                let s = get_string(val)?;
+                let (a, b) = s.split_once($split).expect("split of value failed: ${val}");
+                $builder::$name($self.borrow_mut(), a.to_string(), b.to_string());
+            }
+        }
+    };
+}
+
+/// All non-labeled tunnels have these common configuration options
+macro_rules! config_common {
+    ($builder:tt, $self:tt, $config:tt) => {
+        plumb!($builder, $self, $config, metadata);
+        plumb_vec!($builder, $self, $config, allow_cidr);
+        plumb_vec!($builder, $self, $config, deny_cidr);
+        plumb!($builder, $self, $config, proxy_proto);
+        plumb!($builder, $self, $config, forwards_to);
+    };
+}
+
+fn get_string(v: &PyAny) -> Result<String, PyErr> {
+    v.downcast::<PyString>()?.extract::<String>()
+}
+
+fn get_bool(v: &PyAny) -> Result<bool, PyErr> {
+    v.downcast::<PyBool>()?.extract::<bool>()
+}
+
+fn get_list(v: &PyAny) -> Result<Vec<&PyAny>, PyErr> {
+    if v.is_instance(v.py().get_type::<PyList>())? {
+        return v.downcast::<PyList>()?.extract::<Vec<&PyAny>>();
+    }
+    // turn scalars into lists
+    Ok(vec![v])
+}
+
+fn get_str_list(v: Option<&PyAny>) -> Result<Option<Vec<String>>, PyErr> {
+    // vectorize PyAny's, then convert them to Strings
+    v.map(get_list)
+        .transpose()?
+        .map(|v| v.iter().map(|v| get_string(v)).collect())
+        .transpose()
+}
+
+fn get_byte_array(v: &PyAny) -> Result<&PyByteArray, PyDowncastError> {
+    v.downcast::<PyByteArray>()
+}
+
+/// Establish ngrok ingress, returning an tunnel object.
+///
+/// :param int, str or None addr: The address to forward traffic to, this can be an integer port, or a host:port string, e.g. "localhost:8080"
+/// :param str or None proto: The protocol type of the tunnel, one of "http", "tcp", "tls", "labeled"
+/// :param options: A dict of options to pass to the tunnel.
+/// :return: A tunnel object.
+#[pyfunction]
+#[pyo3(signature = (addr=None, proto=None, **options), text_signature = "(addr=None, proto=None, **options)")]
+pub fn connect(
+    py: Python,
+    addr: Option<&PyAny>,
+    proto: Option<String>,
+    options: Option<&PyDict>,
+) -> PyResult<Py<PyAny>> {
+    let kwargs: &PyDict = options.unwrap_or(PyDict::new(py));
+    // decode address string
+    let mut addr_str = "localhost:80".to_string();
+    if let Some(a) = addr {
+        if a.is_instance(py.get_type::<PyInt>())? {
+            addr_str = format!("localhost:{}", a.downcast::<PyInt>()?.extract::<i32>()?);
+        } else if a.is_instance(py.get_type::<PyString>())? {
+            addr_str = a.downcast::<PyString>()?.extract::<String>()?;
+        }
+    }
+
+    // package up args to kwargs
+    if addr.is_some() || kwargs.get_item("addr").is_none() {
+        kwargs.set_item("addr", addr_str)?;
+    }
+    if proto.is_some() {
+        kwargs.set_item("proto", proto)?;
+    }
+
+    // move to async, handling if there is an async loop running or not
+    wrapper::loop_wrap(
+        py,
+        Some(kwargs.into()),
+        "    return await ngrok.async_connect(input)",
+    )
+}
+
+#[pyfunction]
+pub fn async_connect(py: Python, config: Py<PyDict>) -> PyResult<&PyAny> {
+    pyo3_asyncio::tokio::future_into_py(py, async move { do_connect(config).await })
+}
+
+fn configure_session(options: &Py<PyDict>) -> Result<NgrokSessionBuilder, PyErr> {
+    Python::with_gil(|py: Python| {
+        let s_builder = PyCell::new(py, NgrokSessionBuilder::new())?;
+        let cfg = options.as_ref(py);
+        type B = NgrokSessionBuilder;
+        plumb!(B, s_builder, cfg, authtoken);
+        plumb_bool!(B, s_builder, cfg, authtoken_from_env);
+        plumb!(B, s_builder, cfg, metadata, session_metadata);
+        Ok(s_builder.replace(NgrokSessionBuilder::new()))
+    })
+}
+
+async fn do_connect(options: Py<PyDict>) -> PyResult<PyObject> {
+    // Using a singleton session for connect use cases
+    let mut opt = SESSION.lock().await;
+    if opt.is_none() {
+        opt.replace(configure_session(&options)?.async_connect().await?);
+    }
+    let session = opt.as_ref().unwrap();
+
+    // decode address
+    let addr = Python::with_gil(|py| -> PyResult<String> {
+        // decode address string
+        get_string(options.as_ref(py).get_item("addr").expect("addr set"))
+    })?;
+
+    // decode proto
+    let proto = Python::with_gil(|py| -> PyResult<String> {
+        Ok(match options.as_ref(py).get_item("proto") {
+            Some(p) => get_string(p)?,
+            None => "http".to_string(),
+        })
+    })?;
+
+    // create tunnel
+    let tunnel = match proto.as_str() {
+        "http" => http_endpoint(session, addr, options).await,
+        "tcp" => tcp_endpoint(session, addr, options).await,
+        "tls" => tls_endpoint(session, addr, options).await,
+        "labeled" => labeled_tunnel(session, addr, options).await,
+        _ => Err(py_err(format!("unhandled protocol {proto:?}"))),
+    }?;
+    Ok(Python::with_gil(|py| tunnel.into_py(py)))
+}
+
+/// HTTP tunnel creation and forwarding
+async fn http_endpoint(
+    session: &NgrokSession,
+    addr: String,
+    options: Py<PyDict>,
+) -> PyResult<NgrokTunnel> {
+    let bld = Python::with_gil(|py: Python| {
+        let bld = PyCell::new(py, session.http_endpoint())?;
+        let cfg = options.as_ref(py);
+        type B = NgrokHttpTunnelBuilder;
+        config_common!(B, bld, cfg);
+        plumb_vec!(B, bld, cfg, scheme, schemes);
+        plumb!(B, bld, cfg, domain, hostname); // synonym for domain
+        plumb!(B, bld, cfg, domain);
+        plumb_vec!(B, bld, cfg, mutual_tlsca, mutual_tls_cas, vecu8);
+        plumb_bool!(B, bld, cfg, compression);
+        plumb_bool!(
+            B,
+            bld,
+            cfg,
+            websocket_tcp_conversion,
+            websocket_tcp_converter
+        );
+        plumb_vec!(B, bld, cfg, request_header, request_header_add, ":");
+        plumb_vec!(B, bld, cfg, response_header, response_header_add, ":");
+        plumb_vec!(B, bld, cfg, remove_request_header, request_header_remove);
+        plumb_vec!(B, bld, cfg, remove_response_header, response_header_remove);
+        plumb_vec!(B, bld, cfg, basic_auth, basic_auth, ":");
+        // circuit breaker
+        if let Some(cb) = cfg.get_item("circuit_breaker") {
+            let cb64 = cb.downcast::<PyFloat>()?.extract::<f64>()?;
+            NgrokHttpTunnelBuilder::circuit_breaker(bld.borrow_mut(), cb64);
+        }
+        // oauth
+        if let Some(provider) = cfg.get_item("oauth_provider") {
+            NgrokHttpTunnelBuilder::oauth(
+                bld.borrow_mut(),
+                get_string(provider)?,
+                get_str_list(cfg.get_item("oauth_allow_emails"))?,
+                get_str_list(cfg.get_item("oauth_allow_domains"))?,
+                get_str_list(cfg.get_item("oauth_scopes"))?,
+            );
+        }
+        // oidc
+        if let Some(issuer_url) = cfg.get_item("oidc_issuer_url") {
+            let client_id = cfg.get_item("oidc_client_id").ok_or_else(|| {
+                py_err("Missing client id for oidc. oidc_client_id must be set if oidc_issuer_url is set")
+            })?;
+            let client_secret = cfg.get_item("oidc_client_secret").ok_or_else(|| {
+                py_err("Missing client secret for oidc. oidc_client_secret must be set if oidc_issuer_url is set")
+            })?;
+            NgrokHttpTunnelBuilder::oidc(
+                bld.borrow_mut(),
+                get_string(issuer_url)?,
+                get_string(client_id)?,
+                get_string(client_secret)?,
+                get_str_list(cfg.get_item("oidc_allow_emails"))?,
+                get_str_list(cfg.get_item("oidc_allow_domains"))?,
+                get_str_list(cfg.get_item("oidc_scopes"))?,
+            );
+        }
+        // webhook verification
+        if let Some(provider) = cfg.get_item("verify_webhook_provider") {
+            if let Some(secret) = cfg.get_item("verify_webhook_secret") {
+                NgrokHttpTunnelBuilder::webhook_verification(
+                    bld.borrow_mut(),
+                    get_string(provider)?,
+                    get_string(secret)?,
+                );
+            } else {
+                return Err(py_err("Missing key for tls termination"));
+            }
+        }
+        Ok::<_, PyErr>(bld.replace(session.http_endpoint()))
+    })?;
+    forward(bld.async_listen().await?, addr).await
+}
+
+/// TCP tunnel creation and forwarding
+async fn tcp_endpoint(
+    session: &NgrokSession,
+    addr: String,
+    options: Py<PyDict>,
+) -> PyResult<NgrokTunnel> {
+    let bld = Python::with_gil(|py: Python| {
+        let bld = PyCell::new(py, session.tcp_endpoint())?;
+        let cfg = options.as_ref(py);
+        type B = NgrokTcpTunnelBuilder;
+        config_common!(B, bld, cfg);
+        plumb!(B, bld, cfg, remote_addr);
+        Ok::<_, PyErr>(bld.replace(session.tcp_endpoint()))
+    })?;
+    forward(bld.async_listen().await?, addr).await
+}
+
+/// TLS tunnel creation and forwarding
+async fn tls_endpoint(
+    session: &NgrokSession,
+    addr: String,
+    options: Py<PyDict>,
+) -> PyResult<NgrokTunnel> {
+    let bld = Python::with_gil(|py: Python| {
+        let bld = PyCell::new(py, session.tls_endpoint())?;
+        let cfg = options.as_ref(py);
+        type B = NgrokTlsTunnelBuilder;
+        config_common!(B, bld, cfg);
+        plumb!(B, bld, cfg, domain, hostname); // synonym for domain
+        plumb!(B, bld, cfg, domain);
+        plumb_vec!(B, bld, cfg, mutual_tlsca, mutual_tls_cas, vecu8);
+        // tls termination
+        if let Some(crt) = cfg.get_item("crt") {
+            if let Some(key) = cfg.get_item("key") {
+                NgrokTlsTunnelBuilder::termination(
+                    bld.borrow_mut(),
+                    get_byte_array(crt)?,
+                    get_byte_array(key)?,
+                );
+            } else {
+                return Err(py_err("Missing key for tls termination"));
+            }
+        }
+        Ok::<_, PyErr>(bld.replace(session.tls_endpoint()))
+    })?;
+    forward(bld.async_listen().await?, addr).await
+}
+
+/// Labeled tunnel creation and forwarding
+async fn labeled_tunnel(
+    session: &NgrokSession,
+    addr: String,
+    options: Py<PyDict>,
+) -> PyResult<NgrokTunnel> {
+    let bld = Python::with_gil(|py: Python| {
+        let bld = PyCell::new(py, session.labeled_tunnel())?;
+        let cfg = options.as_ref(py);
+        type B = NgrokLabeledTunnelBuilder;
+        plumb!(B, bld, cfg, metadata);
+        plumb_vec!(B, bld, cfg, label, labels, ":");
+        Ok::<_, PyErr>(bld.replace(session.labeled_tunnel()))
+    })?;
+    forward(bld.async_listen().await?, addr).await
+}
+
+/// Background the tunnel forwarding
+async fn forward(tunnel: NgrokTunnel, addr: String) -> PyResult<NgrokTunnel> {
+    let id = tunnel.id();
+    // move forwarding to another task
+    tokio::spawn(async move {
+        if addr.starts_with("pipe:") {
+            tunnel::forward_pipe(&id, addr.clone().split_off(5)).await
+        } else {
+            tunnel::forward_tcp(&id, addr).await
+        }
+        .map(|_| ())
+    });
+    Ok(tunnel)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,10 @@ use tunnel_builder::{
 };
 
 use crate::{
+    connect::{
+        async_connect,
+        connect as connect_fn,
+    },
     logging::log_level,
     wrapper::{
         default,
@@ -32,6 +36,7 @@ use crate::{
     },
 };
 
+pub mod connect;
 pub mod http;
 pub mod logging;
 pub mod session;
@@ -48,6 +53,8 @@ pub mod wrapper;
 /// The ngrok Agent SDK for Python
 #[pymodule]
 fn ngrok(py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(async_connect, m)?)?;
+    m.add_function(wrap_pyfunction!(connect_fn, m)?)?;
     m.add_function(wrap_pyfunction!(default, m)?)?;
     m.add_function(wrap_pyfunction!(fd, m)?)?;
     m.add_function(wrap_pyfunction!(getsockname, m)?)?;

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -164,10 +164,11 @@ pub fn werkzeug_develop(py: Python, tunnel: Option<Py<PyAny>>) -> PyResult<Py<Py
 }
 
 /// Python wrapper to call the passed in work in an async context whether or not an async loop is running.
-fn loop_wrap(py: Python, input: Option<Py<PyAny>>, work: &str) -> PyResult<Py<PyAny>> {
+pub(crate) fn loop_wrap(py: Python, input: Option<Py<PyAny>>, work: &str) -> PyResult<Py<PyAny>> {
     let code = format!(
         r###"
 import asyncio
+import ngrok
 from ngrok import NgrokSessionBuilder
 import os
 

--- a/test/test.py
+++ b/test/test.py
@@ -3,9 +3,7 @@ from aiohttp.web_runner import GracefulExit
 from collections import defaultdict
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import asyncio
-import logging
 import ngrok
-import http
 import os
 import random
 import requests
@@ -157,8 +155,7 @@ class TestNgrok(unittest.IsolatedAsyncioTestCase):
 
         tunnel.forward_tcp(http_server.listen_to)
 
-        config = dict()
-        config["auth"] = ("ngrok", "online1line")
+        config = {"auth": ("ngrok","online1line")}
         response = await self.forward_validate_shutdown(
             http_server, tunnel, tunnel.url(), config
         )

--- a/test/test_connect.py
+++ b/test/test_connect.py
@@ -1,0 +1,72 @@
+import ngrok
+import requests
+import unittest
+import test
+
+def shutdown(url, http_server):
+    # ngrok.disconnect(url)
+    http_server.shutdown()
+    http_server.server_close()
+
+
+class TestNgrok(unittest.IsolatedAsyncioTestCase):
+    def validate_http_request(self, url, requests_config=dict()):
+        response = requests.get(url, **requests_config)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(test.expected, response.text)
+        return response
+
+    def validate_shutdown(self, http_server, tunnel, url, requests_config=dict()):
+        response = self.validate_http_request(url, requests_config)
+        shutdown(tunnel, http_server)
+        return response
+
+    async def test_https_tunnel_async(self):
+        http_server = test.make_http()
+        tunnel = await ngrok.connect(http_server.listen_to, 
+                               authtoken_from_env=True,
+                               forwards_to="http forwards to", metadata="http metadata")
+        
+        self.assertIsNotNone(tunnel.id())
+        self.assertIsNotNone(tunnel.url())
+        self.assertTrue(tunnel.url().startswith("https://"))
+        self.assertEqual("http forwards to", tunnel.forwards_to())
+        self.assertEqual("http metadata", tunnel.metadata())
+        self.validate_shutdown(http_server, tunnel, tunnel.url())
+
+    def test_https_tunnel(self):
+        http_server = test.make_http()
+        tunnel = ngrok.connect(http_server.listen_to, 
+                               authtoken_from_env=True,
+                               forwards_to="http forwards to", metadata="http metadata")
+        
+        self.assertIsNotNone(tunnel.id())
+        self.assertIsNotNone(tunnel.url())
+        self.assertTrue(tunnel.url().startswith("https://"))
+        self.assertEqual("http forwards to", tunnel.forwards_to())
+        self.assertEqual("http metadata", tunnel.metadata())
+        self.validate_shutdown(http_server, tunnel, tunnel.url())
+    
+    def test_connect_number(self):
+        http_server = test.make_http()
+        tunnel = ngrok.connect(int(http_server.listen_to.split(":")[1]), authtoken_from_env=True)
+        self.validate_shutdown(http_server, tunnel, tunnel.url())
+    
+    def test_connect_vectorize(self):
+        http_server = test.make_http()        
+        tunnel = ngrok.connect(http_server.listen_to, authtoken_from_env=True,
+                                basic_auth="ngrok:online1line",
+                                ip_restriction_allow_cidrs="0.0.0.0/0",
+                                ip_restriction_deny_cidrs="10.1.1.1/32",
+                                request_header_remove="X-Req-Nope2",
+                                response_header_remove="X-Res-Nope2",
+                                request_header_add="X-Req-Yup2:true2",
+                                response_header_add="X-Res-Yup2:true2",
+                                schemes="HTTPS",
+                                )
+        config = {"auth": ("ngrok","online1line")}
+        response = self.validate_shutdown(http_server, tunnel, tunnel.url(), config)
+        self.assertEqual("true2", response.headers["x-res-yup2"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`connect.rs` has the meat of the change, it will take the kwargs from python and churn through macros to populate the builders. Had to pull out the async functions (session.connect() and tunnel_builder.listen()) to make it callable from rust. Rest is tests or examples.

This is analogous to the change in ngrok-js: https://github.com/ngrok/ngrok-js/pull/44