### PR TITLE
carl: Add Streamlit example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,4 @@ Cargo.lock
 *.swp
 __pycache__/
 ngrok.abi3.so
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 PY = python3
 VENV = .env
 BIN=$(VENV)/bin
+SHELL=/bin/bash
 
 # make it work on windows too
 ifeq ($(OS), Windows_NT)
@@ -80,6 +81,9 @@ run-gradio-asgi: develop
 
 run-tornado: develop examples-install
 	. $(BIN)/activate && python ./examples/tornado-ngrok.py
+
+run-streamlit: develop examples-install
+	. $(BIN)/activate && pushd ./examples/streamlit && python streamlit-ngrok.py
 
 run-full: develop
 	. $(BIN)/activate && ./examples/ngrok-http-full.py

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ python -m ngrok gunicorn mysite.asgi:application -k uvicorn.workers.UvicornWorke
 * [Django](https://www.djangoproject.com/) - [Single File Example](https://github.com/ngrok/ngrok-py/tree/main/examples/django-single-file.py), [Modify manage.py Example](https://github.com/ngrok/ngrok-py/tree/main/examples/djangosite/manage.py), [Modify asgi.py Example](https://github.com/ngrok/ngrok-py/tree/main/examples/djangosite/djangosite/ngrok-asgi.py), or use the `ngrok-asgi` ASGI Runner discussed above
 * [Flask](https://flask.palletsprojects.com) - [Example](https://github.com/ngrok/ngrok-py/tree/main/examples/flask-ngrok.py)
 * [Gunicorn](https://gunicorn.org/) - Use the `ngrok-asgi` ASGI Runner discussed above
+* [Streamlit](https://streamlit.io) - [Example](https://github.com/ngrok/ngrok-py/tree/main/examples/streamlit/streamlit-ngrok.py)
 * [Tornado](https://www.tornadoweb.org) - [Example](https://github.com/ngrok/ngrok-py/tree/main/examples/tornado-ngrok.py)
 * [Uvicorn](https://www.uvicorn.org/) - [Example](https://github.com/ngrok/ngrok-py/tree/main/examples/uvicorn-ngrok.py), or use the `ngrok-asgi` ASGI Runner discussed above
 

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -3,4 +3,5 @@ Django==4.1.7
 Flask==2.2.3
 gunicorn==20.1.0
 uvicorn==0.21.0
+streamlit==1.22.0
 tornado==6.3.1

--- a/examples/streamlit/streamlit-demo.py
+++ b/examples/streamlit/streamlit-demo.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+x = st.slider("Select a value")
+st.write(x, "squared is", x * x)

--- a/examples/streamlit/streamlit-ngrok.py
+++ b/examples/streamlit/streamlit-ngrok.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+#
+# For basic launch, run:
+# python streamlit-ngrok.py
+
+import asyncio, ngrok
+import click
+
+from streamlit.web.bootstrap import run 
+
+app_port = 8501
+
+async def setup_tunnel():
+    listen = f"localhost:{app_port}"
+    session = await ngrok.NgrokSessionBuilder().authtoken_from_env().connect()
+    tunnel = await (
+        session.http_endpoint()
+        # .domain('<name>.ngrok.app') # if on a paid plan, set a custom static domain
+        .listen()
+    )
+    click.secho(f"Forwarding to {listen} from ingress url: {tunnel.url()}", fg="green", bold=True)
+    tunnel.forward_tcp(listen)
+
+
+try:
+    # Check if asyncio loop is already running. If so, piggyback on it to run the ngrok tunnel.
+    running_loop = asyncio.get_running_loop()
+    running_loop.create_task(setup_tunnel())
+except RuntimeError:
+    # No existing loop is running, so we can run the ngrok tunnel on a new loop.
+    asyncio.run(setup_tunnel())
+
+run('streamlit-demo.py', command_line=None, args=[], flag_options={})


### PR DESCRIPTION
### What
Adds an example showcasing spinning up an `ngrok` tunnel that points to a [Streamlit](https://streamlit.io) server.

### How 
Added a new `make run-streamlit` for building and running an example using Streamlit.

<img width="578" alt="image" src="https://user-images.githubusercontent.com/11064629/236309511-ff8d1ffb-2a6f-4ee4-a87e-183c31b195bd.png">

<img width="960" alt="image" src="https://user-images.githubusercontent.com/11064629/236309467-dcc8fa8a-324c-48f2-906d-bd5d5f55b7a2.png">
