### PR TITLE
handle http: in addr, and None's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ testpublish:
 	. $(BIN)/activate && maturin publish --repository testpypi
 
 docs: develop black
-	. $(BIN)/activate && sphinx-build -b html doc_source/ docs/
+	. $(BIN)/activate && sphinx-build -a -E -b html doc_source/ docs/
 
 black: develop
 	. $(BIN)/activate && black examples/ test/ python/

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ async def create_tunnel():
     tunnel.forward_tcp("localhost:9000")
 ```
 
+Or with [the 'connect' convenience function](https://github.com/ngrok/ngrok-py/blob/main/examples/ngrok-connect-minimal.py):
+
+```python
+tunnel = ngrok.connect(9000, authtoken_from_env=True)
+print (f"Ingress established at {tunnel.url()}")
+```
+
 # ASGI Runner - Tunnels to Uvicorn, Gunicorn, Django and More, With No Code
 
 Prefix the command line which starts up a Uvicorn or Gunicorn web server with either `ngrok-asgi` or `python -m ngrok`. Any TCP or Unix Domain Socket arguments will be used to establish connectivity automatically. There are many command line arguments to configure the Tunnel used, for instance adding `--basic-auth ngrok online1line` will introduce basic authentication to the ingress tunnel.

--- a/src/http.rs
+++ b/src/http.rs
@@ -88,6 +88,12 @@ impl NgrokHttpTunnelBuilder {
 
     /// OAuth configuration.
     /// If not called, OAuth is disabled.
+    ///
+    /// :param str provider: The name of the OAuth provider to use.
+    /// :param list or None allow_emails: A list of email addresses to allow.
+    /// :param list or None allow_domains: A list of domain names to allow.
+    /// :param list or None scopes: A list of scopes.
+    #[pyo3(text_signature = "(provider, allow_emails=None, allow_domains=None, scopes=None)")]
     pub fn oauth(
         self_: PyRefMut<Self>,
         provider: String,
@@ -118,6 +124,16 @@ impl NgrokHttpTunnelBuilder {
 
     /// OIDC configuration.
     /// If not called, OIDC is disabled.
+    ///
+    /// :param str provider: The name of the OIDC provider to use.
+    /// :param str client_id: The OIDC client ID.
+    /// :param str client_secret: The OIDC client secret.
+    /// :param list or None allow_emails: A list of email addresses to allow.
+    /// :param list or None allow_domains: A list of domain names to allow.
+    /// :param list or None scopes: A list of scopes.
+    #[pyo3(
+        text_signature = "(provider, client_id, client_secret, allow_emails=None, allow_domains=None, scopes=None)"
+    )]
     pub fn oidc(
         self_: PyRefMut<Self>,
         issuer_url: String,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -13,6 +13,9 @@ use crate::py_err;
 
 /// Set the log level for the bridge to Python logging.
 /// The log level defaults to INFO, it can be set to one of ERROR, WARN, INFO, DEBUG, or TRACE.
+///
+/// :param level: The logging level to use (ERROR, WARN, INFO, DEBUG, or TRACE).
+/// :type level: str
 #[pyfunction]
 #[pyo3(text_signature = "(level=\"INFO\")")]
 pub fn log_level(py: Python, level: Option<String>) -> PyResult<()> {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -48,7 +48,13 @@ def run(input=None):
 /// Create a default HTTP tunnel. Optionally pass in a connected NgrokSession to use.
 ///
 /// Returns the tunnel if no async loop is running, otherwise returns a Task to await with a tunnel result.
+///
+/// :param session: The NgrokSession to use to create the tunnel.
+/// :type session: NgrokSession or None
+/// :return: The created tunnel.
+/// :rtype: NgrokTunnel
 #[pyfunction]
+#[pyo3(text_signature = "(session=None)")]
 pub fn default(py: Python, session: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
     default_tunnel_with_return(py, session, "tunnel")
 }
@@ -56,7 +62,13 @@ pub fn default(py: Python, session: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
 /// Create a default HTTP tunnel and get its file descriptor. Optionally pass in a connected NgrokSession to use.
 ///
 /// Returns the file descriptor if no async loop is running, otherwise returns a Task to await with a file descriptor result.
+///
+/// :param session: The NgrokSession to use to create the tunnel.
+/// :type session: NgrokSession or None
+/// :return: The file descriptor of the created tunnel's forwarding socket.
+/// :rtype: int
 #[pyfunction]
+#[pyo3(text_signature = "(session=None)")]
 pub fn fd(py: Python, session: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
     default_tunnel_with_return(py, session, "tunnel.fd")
 }
@@ -64,7 +76,13 @@ pub fn fd(py: Python, session: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
 /// Create a default HTTP tunnel and get its socket name. Optionally pass in a connected NgrokSession to use.
 ///
 /// Returns the socket name if no async loop is running, otherwise returns a Task to await with a socket name result.
+///
+/// :param session: The NgrokSession to use to create the tunnel.
+/// :type session: NgrokSession or None
+/// :return: The name of the created tunnel's forwarding socket.
+/// :rtype: str
 #[pyfunction]
+#[pyo3(text_signature = "(session=None)")]
 pub fn getsockname(py: Python, session: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
     default_tunnel_with_return(py, session, "tunnel.getsockname()")
 }
@@ -94,7 +112,15 @@ fn default_tunnel_with_return(
 /// forward TCP to that server_address. Optionally also pass in a previously created tunnel.
 ///
 /// Returns the created tunnel if no async loop is running, otherwise returns a Task to await with a tunnel result.
+///
+/// :param server: The server to link with a tunnel.
+/// :type server: http.server.HTTPServer or None
+/// :param tunnel: The NgrokTunnel to use to link with the server.
+/// :type tunnel: NgrokTunnel or None
+/// :return: The tunnel linked with the server, or a Task to await for said tunnel.
+/// :rtype: NgrokTunnel or Task
 #[pyfunction]
+#[pyo3(text_signature = "(server=None, tunnel=None)")]
 pub fn listen(
     py: Python,
     server: Option<Py<PyAny>>,
@@ -147,7 +173,13 @@ pub fn listen(
 /// Also sets WERKZEUG_RUN_MAIN to "true" to engage the use of WERKZEUG_SERVER_FD.
 ///
 /// Returns the created tunnel if no async loop is running, otherwise returns a Task to await with a tunnel result.
+///
+/// :param tunnel: The NgrokTunnel to use to link with the werkzeug server.
+/// :type tunnel: NgrokTunnel or None
+/// :return: The tunnel linked with the server, or a Task to await for said tunnel.
+/// :rtype: NgrokTunnel or Task
 #[pyfunction]
+#[pyo3(text_signature = "(tunnel=None)")]
 pub fn werkzeug_develop(py: Python, tunnel: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
     loop_wrap(
         py,

--- a/test/test_connect.py
+++ b/test/test_connect.py
@@ -61,6 +61,18 @@ class TestNgrok(unittest.IsolatedAsyncioTestCase):
         )
         self.validate_shutdown(http_server, tunnel, tunnel.url())
 
+    def test_connect_addr_protocol(self):
+        http_server = test.make_http()
+        tunnel = ngrok.connect(
+            f"http://{http_server.listen_to}",  # http:// should be ignored
+            authtoken_from_env=True,
+            authtoken=None,  # None's should be ignored
+            basic_auth=None,
+            circuit_breaker=None,
+            mutual_tls_cas=None,
+        )
+        self.validate_shutdown(http_server, tunnel, tunnel.url())
+
     def test_connect_vectorize(self):
         http_server = test.make_http()
         tunnel = ngrok.connect(


### PR DESCRIPTION
Make the connect interface more friendly, items found during hackathon. Also spruce up generated docs to remove ellipses and specify types, and add `connect` to the README.