### PR TITLE
add ngrok.disconnect(url) and ngrok.kill()

### DIFF
--- a/doc_source/module.rst
+++ b/doc_source/module.rst
@@ -2,6 +2,6 @@ Ngrok Module
 =====================================
 
 .. automodule:: ngrok
-   :members: connect, default, fd, getsockname, listen, log_level, pipe_name, werkzeug_develop
+   :members: connect, default, disconnect, fd, getsockname, kill, listen, log_level, pipe_name, werkzeug_develop
    :noindex:
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -197,6 +197,10 @@ pub fn connect(
         if let Some(v) = kwargs.get_item(k) {
             if v.is_none() {
                 kwargs.del_item(k)?;
+            } else if get_string(k)?.contains('.') {
+                // handle cases like "oauth.provider" -> "oauth_provider"
+                kwargs.del_item(k)?;
+                kwargs.set_item(get_string(k)?.replace('.', "_"), v)?;
             }
         }
     }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -416,3 +416,38 @@ async fn forward(tunnel: NgrokTunnel, addr: String) -> PyResult<NgrokTunnel> {
     });
     Ok(tunnel)
 }
+
+/// Shut down all tunnels and sessions.
+#[pyfunction]
+pub fn kill(py: Python) -> PyResult<Py<PyAny>> {
+    disconnect(py, None)
+}
+
+/// Shut down tunnel with the given url, or if no url is given, shut down all tunnels.
+///
+/// :param str or None url: The url of the NgrokTunnel to disconnect, or None to disconnect all tunnels.
+#[pyfunction]
+#[pyo3(text_signature = "(url=None)")]
+pub fn disconnect(py: Python, url: Option<Py<PyString>>) -> PyResult<Py<PyAny>> {
+    // move to async, handling if there is an async loop running or not
+    wrapper::loop_wrap(
+        py,
+        url.map(|u| u.into()),
+        "    return await ngrok.async_disconnect(input)",
+    )
+}
+
+#[pyfunction]
+pub fn async_disconnect(py: Python, url: Option<String>) -> PyResult<&PyAny> {
+    info!("async Disconnecting");
+    pyo3_asyncio::tokio::future_into_py(py, async move {
+        tunnel::close_url(url.clone()).await?;
+
+        // if closing every tunnel, remove any stored session
+        if url.is_none() {
+            SESSION.lock().await.take();
+        }
+
+        Ok(())
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,10 @@ use tunnel_builder::{
 use crate::{
     connect::{
         async_connect,
+        async_disconnect,
         connect as connect_fn,
+        disconnect,
+        kill,
     },
     logging::log_level,
     wrapper::{
@@ -54,10 +57,13 @@ pub mod wrapper;
 #[pymodule]
 fn ngrok(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(async_connect, m)?)?;
+    m.add_function(wrap_pyfunction!(async_disconnect, m)?)?;
     m.add_function(wrap_pyfunction!(connect_fn, m)?)?;
     m.add_function(wrap_pyfunction!(default, m)?)?;
+    m.add_function(wrap_pyfunction!(disconnect, m)?)?;
     m.add_function(wrap_pyfunction!(fd, m)?)?;
     m.add_function(wrap_pyfunction!(getsockname, m)?)?;
+    m.add_function(wrap_pyfunction!(kill, m)?)?;
     m.add_function(wrap_pyfunction!(listen, m)?)?;
     m.add_function(wrap_pyfunction!(log_level, m)?)?;
     m.add_function(wrap_pyfunction!(pipe_name, m)?)?;

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -52,6 +52,7 @@ use crate::{
     },
 };
 
+/// Python dictionary of id's to sockets.
 static SOCK_CELL: GILOnceCell<Py<PyDict>> = GILOnceCell::new();
 
 lazy_static! {
@@ -444,6 +445,7 @@ pub(crate) async fn remove_global_tunnel(id: &String) -> PyResult<()> {
             // close socket if it exists
             let existing = dict.get_item(id);
             if let Some(existing) = existing {
+                debug!("closing socket: {}", id);
                 existing.call_method0("close")?;
 
                 // delete reference

--- a/test/test_connect.py
+++ b/test/test_connect.py
@@ -73,6 +73,12 @@ class TestNgrok(unittest.IsolatedAsyncioTestCase):
         )
         self.validate_shutdown(http_server, tunnel, tunnel.url())
 
+    def test_connect_dots(self):
+        http_server = test.make_http()
+        options = {"authtoken.from.env": True}
+        tunnel = ngrok.connect(http_server.listen_to, **options)
+        self.validate_shutdown(http_server, tunnel, tunnel.url())
+
     def test_connect_vectorize(self):
         http_server = test.make_http()
         tunnel = ngrok.connect(

--- a/test/test_connect.py
+++ b/test/test_connect.py
@@ -5,7 +5,7 @@ import test
 
 
 def shutdown(url, http_server):
-    # ngrok.disconnect(url)
+    ngrok.disconnect(url)
     http_server.shutdown()
     http_server.server_close()
 
@@ -19,7 +19,7 @@ class TestNgrok(unittest.IsolatedAsyncioTestCase):
 
     def validate_shutdown(self, http_server, tunnel, url, requests_config=dict()):
         response = self.validate_http_request(url, requests_config)
-        shutdown(tunnel, http_server)
+        shutdown(url, http_server)
         return response
 
     async def test_https_tunnel_async(self):


### PR DESCRIPTION
Add `disconnect(url)`, `kill()` and dots-to-underscores to mirror other python ngrok libraries as well as ngrok-js.